### PR TITLE
fix: add missing rdfs:domain/rdfs:range to all derived ontology properties

### DIFF
--- a/ontology-reference-models/derived-ontologies/BSP/current/commercial/commercial.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/commercial/commercial.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix fin: <https://www.kairosflow.ai/ont/bsp/financial#> .
+@prefix refdata: <https://www.kairosflow.ai/ont/bsp/reference-data#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -16,7 +18,7 @@
     - Events: Business events, order events, shipment events""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -213,6 +215,7 @@
 :hasShipment a owl:ObjectProperty ;
     rdfs:label "has shipment" ;
     rdfs:comment "Relates order or transaction to shipment." ;
+    rdfs:domain :CommercialTransaction ;
     rdfs:range :Shipment .
 
 :hasShipmentLine a owl:ObjectProperty ;
@@ -236,21 +239,25 @@
 :hasEvent a owl:ObjectProperty ;
     rdfs:label "has event" ;
     rdfs:comment "Relates entity to business events." ;
+    rdfs:domain :CommercialTransaction ;
     rdfs:range :BusinessEvent .
 
 :occursAtLocation a owl:ObjectProperty ;
     rdfs:label "occurs at location" ;
     rdfs:comment "Relates event to location." ;
-    rdfs:domain :BusinessEvent .
+    rdfs:domain :BusinessEvent ;
+    rdfs:range refdata:Location .
 
 :relatedToOrder a owl:ObjectProperty ;
     rdfs:label "related to order" ;
     rdfs:comment "Links shipment or invoice to originating order." ;
+    rdfs:domain :Shipment ;
     rdfs:range :PurchaseOrder .
 
 :relatedToShipment a owl:ObjectProperty ;
     rdfs:label "related to shipment" ;
     rdfs:comment "Links invoice to associated shipment." ;
+    rdfs:domain fin:Invoice ;
     rdfs:range :Shipment .
 
 #################################################################
@@ -266,36 +273,43 @@
 :orderDate a owl:DatatypeProperty ;
     rdfs:label "order date" ;
     rdfs:comment "Date when order was placed." ;
+    rdfs:domain :PurchaseOrder ;
     rdfs:range xsd:date .
 
 :requestedDeliveryDate a owl:DatatypeProperty ;
     rdfs:label "requested delivery date" ;
     rdfs:comment "Date when delivery is requested." ;
+    rdfs:domain :PurchaseOrder ;
     rdfs:range xsd:date .
 
 :lineNumber a owl:DatatypeProperty ;
     rdfs:label "line number" ;
     rdfs:comment "Sequential line item number." ;
+    rdfs:domain :OrderLine ;
     rdfs:range xsd:integer .
 
 :quantity a owl:DatatypeProperty ;
     rdfs:label "quantity" ;
     rdfs:comment "Number of units." ;
+    rdfs:domain :OrderLine ;
     rdfs:range xsd:decimal .
 
 :unitOfMeasure a owl:DatatypeProperty ;
     rdfs:label "unit of measure" ;
     rdfs:comment "Unit in which quantity is expressed (e.g., EA, KG, M)." ;
+    rdfs:domain :OrderLine ;
     rdfs:range xsd:string .
 
 :unitPrice a owl:DatatypeProperty ;
     rdfs:label "unit price" ;
     rdfs:comment "Price per unit." ;
+    rdfs:domain :OrderLine ;
     rdfs:range xsd:decimal .
 
 :lineAmount a owl:DatatypeProperty ;
     rdfs:label "line amount" ;
     rdfs:comment "Total amount for line (quantity × unit price)." ;
+    rdfs:domain :OrderLine ;
     rdfs:range xsd:decimal .
 
 :productCode a owl:DatatypeProperty ;
@@ -325,21 +339,25 @@
 :shipmentDate a owl:DatatypeProperty ;
     rdfs:label "shipment date" ;
     rdfs:comment "Date when shipment occurs." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:date .
 
 :expectedDeliveryDate a owl:DatatypeProperty ;
     rdfs:label "expected delivery date" ;
     rdfs:comment "Expected date of delivery." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:date .
 
 :actualDeliveryDate a owl:DatatypeProperty ;
     rdfs:label "actual delivery date" ;
     rdfs:comment "Actual date of delivery." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:date .
 
 :incoterm a owl:DatatypeProperty ;
     rdfs:label "Incoterm" ;
     rdfs:comment "International Commercial Terms (e.g., FOB, CIF, EXW, DDP)." ;
+    rdfs:domain :CommercialTransaction ;
     rdfs:range xsd:string .
 
 :eventDateTime a owl:DatatypeProperty ;
@@ -363,24 +381,29 @@
 :numberOfPackages a owl:DatatypeProperty ;
     rdfs:label "number of packages" ;
     rdfs:comment "Total number of packages." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:integer .
 
 :packageType a owl:DatatypeProperty ;
     rdfs:label "package type" ;
     rdfs:comment "Type of packaging (e.g., CARTON, PALLET, CRATE)." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:string .
 
 :grossWeight a owl:DatatypeProperty ;
     rdfs:label "gross weight" ;
     rdfs:comment "Total weight including packaging (kg)." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:decimal .
 
 :netWeight a owl:DatatypeProperty ;
     rdfs:label "net weight" ;
     rdfs:comment "Weight of goods only (kg)." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:decimal .
 
 :volumeMeasure a owl:DatatypeProperty ;
     rdfs:label "volume measure" ;
     rdfs:comment "Volume in cubic meters." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:decimal .

--- a/ontology-reference-models/derived-ontologies/BSP/current/compliance/compliance.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/compliance/compliance.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
+@prefix refdata: <https://www.kairosflow.ai/ont/bsp/reference-data#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -18,7 +20,7 @@
     - Events: Customs clearance lifecycle events""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -76,11 +78,14 @@
 :hasTariffClassification a owl:ObjectProperty ;
     rdfs:label "has tariff classification" ;
     rdfs:comment "Relates product to tariff classification." ;
+    rdfs:domain comm:Product ;
     rdfs:range :TariffClassification .
 
 :hasCountryOfOrigin a owl:ObjectProperty ;
     rdfs:label "has country of origin" ;
-    rdfs:comment "Identifies country where goods were produced." .
+    rdfs:comment "Identifies country where goods were produced." ;
+    rdfs:domain comm:Product ;
+    rdfs:range refdata:Country .
 
 #################################################################
 #    Datatype Properties
@@ -89,6 +94,7 @@
 :hsCode a owl:DatatypeProperty ;
     rdfs:label "HS code" ;
     rdfs:comment "Harmonized System tariff classification code." ;
+    rdfs:domain :TariffClassification ;
     rdfs:range xsd:string .
 
 :dutyRate a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/BSP/current/documents/documents.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/documents/documents.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -18,7 +19,7 @@
     - Events: Document lifecycle events""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -150,16 +151,19 @@
 :hasDocument a owl:ObjectProperty ;
     rdfs:label "has document" ;
     rdfs:comment "Relates entity to associated documents." ;
+    rdfs:domain comm:CommercialTransaction ;
     rdfs:range :Document .
 
 :hasTransportDocument a owl:ObjectProperty ;
     rdfs:label "has transport document" ;
     rdfs:comment "Relates shipment to transport documents." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :TransportDocument .
 
 :hasCustomsDeclaration a owl:ObjectProperty ;
     rdfs:label "has customs declaration" ;
     rdfs:comment "Relates shipment to customs documents." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :CustomsDeclaration .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/BSP/current/financial/financial.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/financial/financial.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -17,7 +18,7 @@
     - Events: Payment lifecycle events""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -121,6 +122,7 @@
 :hasInvoice a owl:ObjectProperty ;
     rdfs:label "has invoice" ;
     rdfs:comment "Relates order or shipment to invoice." ;
+    rdfs:domain comm:CommercialTransaction ;
     rdfs:range :Invoice .
 
 :hasInvoiceLine a owl:ObjectProperty ;
@@ -138,6 +140,7 @@
 :hasPaymentTerms a owl:ObjectProperty ;
     rdfs:label "has payment terms" ;
     rdfs:comment "Relates invoice or order to payment terms." ;
+    rdfs:domain :Invoice ;
     rdfs:range :PaymentTerms .
 
 #################################################################
@@ -159,36 +162,43 @@
 :dueDate a owl:DatatypeProperty ;
     rdfs:label "due date" ;
     rdfs:comment "Date when payment is due." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:date .
 
 :lineNumber a owl:DatatypeProperty ;
     rdfs:label "line number" ;
     rdfs:comment "Sequential line item number." ;
+    rdfs:domain :InvoiceLine ;
     rdfs:range xsd:integer .
 
 :totalAmount a owl:DatatypeProperty ;
     rdfs:label "total amount" ;
     rdfs:comment "Total monetary amount." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:decimal .
 
 :subtotalAmount a owl:DatatypeProperty ;
     rdfs:label "subtotal amount" ;
     rdfs:comment "Amount before taxes and charges." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:decimal .
 
 :taxAmount a owl:DatatypeProperty ;
     rdfs:label "tax amount" ;
     rdfs:comment "Total tax amount (VAT, sales tax, etc.)." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:decimal .
 
 :taxRate a owl:DatatypeProperty ;
     rdfs:label "tax rate" ;
     rdfs:comment "Tax percentage rate." ;
+    rdfs:domain :InvoiceLine ;
     rdfs:range xsd:decimal .
 
 :discountAmount a owl:DatatypeProperty ;
     rdfs:label "discount amount" ;
     rdfs:comment "Discount applied." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:decimal .
 
 :paymentAmount a owl:DatatypeProperty ;
@@ -206,6 +216,7 @@
 :paymentMethod a owl:DatatypeProperty ;
     rdfs:label "payment method" ;
     rdfs:comment "Method of payment (e.g., BANK_TRANSFER, CREDIT_CARD, L/C)." ;
+    rdfs:domain :Payment ;
     rdfs:range xsd:string .
 
 :paymentReference a owl:DatatypeProperty ;
@@ -217,11 +228,13 @@
 :currency a owl:DatatypeProperty ;
     rdfs:label "currency" ;
     rdfs:comment "ISO 4217 currency code (e.g., USD, EUR, GBP)." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:string .
 
 :exchangeRate a owl:DatatypeProperty ;
     rdfs:label "exchange rate" ;
     rdfs:comment "Currency exchange rate." ;
+    rdfs:domain :Invoice ;
     rdfs:range xsd:decimal .
 
 :paymentTermsDescription a owl:DatatypeProperty ;
@@ -239,4 +252,5 @@
 :customsValue a owl:DatatypeProperty ;
     rdfs:label "customs value" ;
     rdfs:comment "Declared value for customs purposes." ;
+    rdfs:domain :CommercialInvoice ;
     rdfs:range xsd:decimal .

--- a/ontology-reference-models/derived-ontologies/BSP/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/party/party.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -17,7 +18,7 @@
     - Supply chain participants (Manufacturer, Supplier, Notify Party)""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -120,31 +121,37 @@
 :hasBuyer a owl:ObjectProperty ;
     rdfs:label "has buyer" ;
     rdfs:comment "Identifies the buyer." ;
+    rdfs:domain comm:CommercialTransaction ;
     rdfs:range :Buyer .
 
 :hasSeller a owl:ObjectProperty ;
     rdfs:label "has seller" ;
     rdfs:comment "Identifies the seller." ;
+    rdfs:domain comm:CommercialTransaction ;
     rdfs:range :Seller .
 
 :hasShipper a owl:ObjectProperty ;
     rdfs:label "has shipper" ;
     rdfs:comment "Identifies the shipper/consignor." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :Shipper .
 
 :hasConsignee a owl:ObjectProperty ;
     rdfs:label "has consignee" ;
     rdfs:comment "Identifies the consignee." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :Consignee .
 
 :hasCarrier a owl:ObjectProperty ;
     rdfs:label "has carrier" ;
     rdfs:comment "Identifies the carrier." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :Carrier .
 
 :hasManufacturer a owl:ObjectProperty ;
     rdfs:label "has manufacturer" ;
     rdfs:comment "Identifies the manufacturer." ;
+    rdfs:domain comm:Product ;
     rdfs:range :Manufacturer .
 
 #################################################################
@@ -166,9 +173,11 @@
 :contactEmail a owl:DatatypeProperty ;
     rdfs:label "contact email" ;
     rdfs:comment "Email address for contact." ;
+    rdfs:domain :TradeParty ;
     rdfs:range xsd:string .
 
 :contactPhone a owl:DatatypeProperty ;
     rdfs:label "contact phone" ;
     rdfs:comment "Phone number for contact." ;
+    rdfs:domain :TradeParty ;
     rdfs:range xsd:string .

--- a/ontology-reference-models/derived-ontologies/BSP/current/reference-data/reference-data.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/reference-data/reference-data.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
+@prefix party: <https://www.kairosflow.ai/ont/bsp/party#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -17,7 +19,7 @@
     - Code lists: UN/LOCODE, IATA codes, country codes""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0)" ;
     rdfs:seeAlso <https://vocabulary.uncefact.org/> .
@@ -136,21 +138,25 @@
 :hasBillingAddress a owl:ObjectProperty ;
     rdfs:label "has billing address" ;
     rdfs:comment "Identifies billing address." ;
+    rdfs:domain party:TradeParty ;
     rdfs:range :Address .
 
 :hasShippingAddress a owl:ObjectProperty ;
     rdfs:label "has shipping address" ;
     rdfs:comment "Identifies shipping/delivery address." ;
+    rdfs:domain party:TradeParty ;
     rdfs:range :Address .
 
 :hasOriginLocation a owl:ObjectProperty ;
     rdfs:label "has origin location" ;
     rdfs:comment "Identifies origin location." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :Location .
 
 :hasDestinationLocation a owl:ObjectProperty ;
     rdfs:label "has destination location" ;
     rdfs:comment "Identifies destination location." ;
+    rdfs:domain comm:Shipment ;
     rdfs:range :Location .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix equip: <https://www.kairosflow.ai/ont/dcsa/equipment#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -18,7 +19,7 @@
     stuffing/stripping operations, and Lift-on/Lift-off (LoLo) handling.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Track & Trace API v2.2 (equipment event types)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> .
@@ -70,11 +71,14 @@
 
 :hasContainerJourney a owl:ObjectProperty ;
     rdfs:label "has container journey" ;
-    rdfs:comment "Relates a container or shipment to its container journey lifecycle." .
+    rdfs:comment "Relates a container or shipment to its container journey lifecycle." ;
+    rdfs:domain equip:Container ;
+    rdfs:range :ContainerJourney .
 
 :hasOperationalStatus a owl:ObjectProperty ;
     rdfs:label "has operational status" ;
     rdfs:comment "Relates a container to its current operational status." ;
+    rdfs:domain :ContainerJourney ;
     rdfs:range :ContainerOperationalStatus .
 
 :hasStuffingOperation a owl:ObjectProperty ;

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl
@@ -126,16 +126,19 @@
 :temperatureUnit a owl:DatatypeProperty ;
     rdfs:label "temperature unit" ;
     rdfs:comment "Unit: CEL (Celsius) or FAH (Fahrenheit)." ;
+    rdfs:domain :ReeferContainer ;
     rdfs:range xsd:string .
 
 :humidityPercent a owl:DatatypeProperty ;
     rdfs:label "humidity percent" ;
     rdfs:comment "Required humidity percentage." ;
+    rdfs:domain :ReeferContainer ;
     rdfs:range xsd:decimal .
 
 :ventilationSetting a owl:DatatypeProperty ;
     rdfs:label "ventilation setting" ;
     rdfs:comment "Ventilation in cubic meters per hour." ;
+    rdfs:domain :ReeferContainer ;
     rdfs:range xsd:decimal .
 
 :isShipperOwned a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl
@@ -4,6 +4,11 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix td: <https://www.kairosflow.ai/ont/dcsa/transport-documents#> .
+@prefix equip: <https://www.kairosflow.ai/ont/dcsa/equipment#> .
+@prefix party: <https://www.kairosflow.ai/ont/dcsa/party#> .
+@prefix loc: <https://www.kairosflow.ai/ont/dcsa/locations#> .
+@prefix evt: <https://www.kairosflow.ai/ont/dcsa/events#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -15,7 +20,7 @@
     utilized transport equipment.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Booking API (BKG) v2.0" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> .
@@ -124,11 +129,13 @@
 :hasTransportDocument a owl:ObjectProperty ;
     rdfs:label "has transport document" ;
     rdfs:comment "Relates a shipment to its transport document." ;
-    rdfs:domain :Shipment .
+    rdfs:domain :Shipment ;
+    rdfs:range td:TransportDocument .
 
 :hasCargoItem a owl:ObjectProperty ;
     rdfs:label "has cargo item" ;
     rdfs:comment "Relates a booking or shipment to cargo items." ;
+    rdfs:domain :Booking ;
     rdfs:range :CargoItem .
 
 :hasCommodity a owl:ObjectProperty ;
@@ -152,52 +159,74 @@
 :hasContainer a owl:ObjectProperty ;
     rdfs:label "has container" ;
     rdfs:comment "Relates equipment to specific container." ;
-    rdfs:domain :UtilizedTransportEquipment .
+    rdfs:domain :UtilizedTransportEquipment ;
+    rdfs:range equip:Container .
 
 :hasShipper a owl:ObjectProperty ;
     rdfs:label "has shipper" ;
-    rdfs:comment "Identifies the shipper." .
+    rdfs:comment "Identifies the shipper." ;
+    rdfs:domain :Shipment ;
+    rdfs:range party:Shipper .
 
 :hasConsignee a owl:ObjectProperty ;
     rdfs:label "has consignee" ;
-    rdfs:comment "Identifies the consignee." .
+    rdfs:comment "Identifies the consignee." ;
+    rdfs:domain :Shipment ;
+    rdfs:range party:Consignee .
 
 :hasCarrier a owl:ObjectProperty ;
     rdfs:label "has carrier" ;
-    rdfs:comment "Identifies the ocean carrier." .
+    rdfs:comment "Identifies the ocean carrier." ;
+    rdfs:domain :Shipment ;
+    rdfs:range party:Carrier .
 
 :hasBookingParty a owl:ObjectProperty ;
     rdfs:label "has booking party" ;
     rdfs:comment "Identifies the booking party." ;
-    rdfs:domain :Booking .
+    rdfs:domain :Booking ;
+    rdfs:range party:BookingParty .
 
 :hasNotifyParty a owl:ObjectProperty ;
     rdfs:label "has notify party" ;
-    rdfs:comment "Identifies a notify party." .
+    rdfs:comment "Identifies a notify party." ;
+    rdfs:domain :Shipment ;
+    rdfs:range party:NotifyParty .
 
 :hasPlaceOfReceipt a owl:ObjectProperty ;
     rdfs:label "has place of receipt" ;
-    rdfs:comment "Identifies place where cargo is received." .
+    rdfs:comment "Identifies place where cargo is received." ;
+    rdfs:domain :Booking ;
+    rdfs:range loc:PlaceOfReceipt .
 
 :hasPortOfLoading a owl:ObjectProperty ;
     rdfs:label "has port of loading" ;
-    rdfs:comment "Identifies port of loading." .
+    rdfs:comment "Identifies port of loading." ;
+    rdfs:domain :Booking ;
+    rdfs:range loc:PortOfLoading .
 
 :hasPortOfDischarge a owl:ObjectProperty ;
     rdfs:label "has port of discharge" ;
-    rdfs:comment "Identifies port of discharge." .
+    rdfs:comment "Identifies port of discharge." ;
+    rdfs:domain :Booking ;
+    rdfs:range loc:PortOfDischarge .
 
 :hasPlaceOfDelivery a owl:ObjectProperty ;
     rdfs:label "has place of delivery" ;
-    rdfs:comment "Identifies place of final delivery." .
+    rdfs:comment "Identifies place of final delivery." ;
+    rdfs:domain :Booking ;
+    rdfs:range loc:PlaceOfDelivery .
 
 :hasTransshipmentPort a owl:ObjectProperty ;
     rdfs:label "has transshipment port" ;
-    rdfs:comment "Identifies a transshipment port." .
+    rdfs:comment "Identifies a transshipment port." ;
+    rdfs:domain :Booking ;
+    rdfs:range loc:TransshipmentPort .
 
 :hasEvent a owl:ObjectProperty ;
     rdfs:label "has event" ;
-    rdfs:comment "Relates shipment or container to events." .
+    rdfs:comment "Relates shipment or container to events." ;
+    rdfs:domain :Shipment ;
+    rdfs:range evt:Event .
 
 #################################################################
 #    Datatype Properties
@@ -230,74 +259,89 @@
 :equipmentReference a owl:DatatypeProperty ;
     rdfs:label "equipment reference" ;
     rdfs:comment "Reference to specific equipment." ;
+    rdfs:domain :UtilizedTransportEquipment ;
     rdfs:range xsd:string .
 
 :numberOfPackages a owl:DatatypeProperty ;
     rdfs:label "number of packages" ;
     rdfs:comment "Total number of packages." ;
+    rdfs:domain :CargoItem ;
     rdfs:range xsd:integer .
 
 :packageCode a owl:DatatypeProperty ;
     rdfs:label "package code" ;
     rdfs:comment "UN/CEFACT package type code." ;
+    rdfs:domain :CargoItem ;
     rdfs:range xsd:string .
 
 :volume a owl:DatatypeProperty ;
     rdfs:label "volume" ;
     rdfs:comment "Volume in cubic meters." ;
+    rdfs:domain :CargoItem ;
     rdfs:range xsd:decimal .
 
 :weight a owl:DatatypeProperty ;
     rdfs:label "weight" ;
     rdfs:comment "Weight in kilograms." ;
+    rdfs:domain :CargoItem ;
     rdfs:range xsd:decimal .
 
 :hsCode a owl:DatatypeProperty ;
     rdfs:label "HS code" ;
     rdfs:comment "Harmonized System commodity classification code." ;
+    rdfs:domain :Commodity ;
     rdfs:range xsd:string .
 
 :commodityDescription a owl:DatatypeProperty ;
     rdfs:label "commodity description" ;
     rdfs:comment "Description of the goods." ;
+    rdfs:domain :Commodity ;
     rdfs:range xsd:string .
 
 :cargoGrossWeight a owl:DatatypeProperty ;
     rdfs:label "cargo gross weight" ;
     rdfs:comment "Total weight of cargo in kg." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:decimal .
 
 :freightPaymentTerm a owl:DatatypeProperty ;
     rdfs:label "freight payment term" ;
     rdfs:comment "Freight payment terms: PREPAID, COLLECT." ;
+    rdfs:domain :Booking ;
     rdfs:range xsd:string .
 
 :incoterm a owl:DatatypeProperty ;
     rdfs:label "Incoterm" ;
     rdfs:comment "International Commercial Terms code (e.g., FOB, CIF, FCA)." ;
+    rdfs:domain :Booking ;
     rdfs:range xsd:string .
 
 :serviceContractReference a owl:DatatypeProperty ;
     rdfs:label "service contract reference" ;
     rdfs:comment "Reference to carrier service contract." ;
+    rdfs:domain :Booking ;
     rdfs:range xsd:string .
 
 :vesselName a owl:DatatypeProperty ;
     rdfs:label "vessel name" ;
     rdfs:comment "Name of the ocean vessel." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:string .
 
 :vesselIMONumber a owl:DatatypeProperty ;
     rdfs:label "vessel IMO number" ;
     rdfs:comment "International Maritime Organization vessel identifier." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:string .
 
 :voyageNumber a owl:DatatypeProperty ;
     rdfs:label "voyage number" ;
     rdfs:comment "Voyage or sailing reference." ;
+    rdfs:domain :Shipment ;
     rdfs:range xsd:string .
 
 :carrierCode a owl:DatatypeProperty ;
     rdfs:label "carrier code" ;
     rdfs:comment "SCAC (Standard Carrier Alpha Code) or other carrier identifier." ;
+    rdfs:domain :Booking ;
     rdfs:range xsd:string .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/events/events.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/events/events.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix loc: <https://www.kairosflow.ai/ont/dcsa/locations#> .
+@prefix equip: <https://www.kairosflow.ai/ont/dcsa/equipment#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -15,7 +17,7 @@
     and document events (issuance, surrender).""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Track & Trace (TNT) API v2.2" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> .
@@ -133,12 +135,14 @@
 :occursAtLocation a owl:ObjectProperty ;
     rdfs:label "occurs at location" ;
     rdfs:comment "Relates event to location where it occurred." ;
-    rdfs:domain :Event .
+    rdfs:domain :Event ;
+    rdfs:range loc:Location .
 
 :involvesContainer a owl:ObjectProperty ;
     rdfs:label "involves container" ;
     rdfs:comment "Relates equipment event to specific container." ;
-    rdfs:domain :EquipmentEvent .
+    rdfs:domain :EquipmentEvent ;
+    rdfs:range equip:Container .
 
 #################################################################
 #    Datatype Properties
@@ -165,19 +169,23 @@
 :estimatedTimeOfArrival a owl:DatatypeProperty ;
     rdfs:label "estimated time of arrival (ETA)" ;
     rdfs:comment "Estimated vessel arrival time." ;
+    rdfs:domain :VesselArrivalEvent ;
     rdfs:range xsd:dateTime .
 
 :estimatedTimeOfDeparture a owl:DatatypeProperty ;
     rdfs:label "estimated time of departure (ETD)" ;
     rdfs:comment "Estimated vessel departure time." ;
+    rdfs:domain :VesselDepartureEvent ;
     rdfs:range xsd:dateTime .
 
 :actualTimeOfArrival a owl:DatatypeProperty ;
     rdfs:label "actual time of arrival (ATA)" ;
     rdfs:comment "Actual vessel arrival time." ;
+    rdfs:domain :VesselArrivalEvent ;
     rdfs:range xsd:dateTime .
 
 :actualTimeOfDeparture a owl:DatatypeProperty ;
     rdfs:label "actual time of departure (ATD)" ;
     rdfs:comment "Actual vessel departure time." ;
+    rdfs:domain :VesselDepartureEvent ;
     rdfs:range xsd:dateTime .

--- a/ontology-reference-models/derived-ontologies/IMO/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/party/party.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix loc: <https://www.kairosflow.ai/ont/imo/locations#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -16,10 +17,11 @@
     identifying responsible parties in port call and vessel registration processes.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "IMO Compendium data set, FAL Convention, ISM Code, STCW Convention" ;
-    rdfs:seeAlso <https://imocompendium.imo.org/public/IMO-Compendium/Current> .
+    rdfs:seeAlso <https://imocompendium.imo.org/public/IMO-Compendium/Current> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/locations#> .
 
 #################################################################
 #    Classes
@@ -149,7 +151,8 @@
 :providesServiceAt a owl:ObjectProperty ;
     rdfs:label "provides service at" ;
     rdfs:comment "Associates a service provider (pilot, towage) with the port or location where it operates." ;
-    rdfs:domain :MaritimeParty .
+    rdfs:domain :MaritimeParty ;
+    rdfs:range loc:MaritimeLocation .
 
 #################################################################
 #    Datatype Properties

--- a/ontology-reference-models/derived-ontologies/IMO/current/port-call/port-call.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/port-call/port-call.ttl
@@ -16,7 +16,7 @@
     Model for port calls and the FAL Convention electronic data exchange requirements.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "IMO Compendium data set, FAL Convention (2023 amendments)" ;
     rdfs:seeAlso <https://imocompendium.imo.org/public/IMO-Compendium/Current> .
@@ -198,6 +198,10 @@
 :partOfVoyage a owl:ObjectProperty ;
     rdfs:label "part of voyage" ;
     rdfs:comment "Associates a port call or sea leg with its parent voyage." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :PortCall :SeaLeg )
+    ] ;
     rdfs:range :Voyage ;
     owl:inverseOf :hasPortCall .
 
@@ -250,6 +254,10 @@
 :requestedTime a owl:DatatypeProperty ;
     rdfs:label "requested time" ;
     rdfs:comment "The requested date and time for a service (pilotage, towage, etc.)." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :PilotageRequest :TowageRequest )
+    ] ;
     rdfs:range xsd:dateTime .
 
 :falFormNumber a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/MMT/current/cargo/cargo.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/cargo/cargo.ttl
@@ -14,7 +14,7 @@
     commodity classifications, and handling requirements. Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -135,7 +135,9 @@
 
 :weightUnit a owl:DatatypeProperty ;
     rdfs:label "weight unit" ;
-    rdfs:comment "Unit of weight measurement (KG, LB, TON)." .
+    rdfs:comment "Unit of weight measurement (KG, LB, TON)." ;
+    rdfs:domain :Weight ;
+    rdfs:range xsd:string .
 
 #################################################################
 #    Instruction Classes (UN/CEFACT RABIE v101)
@@ -207,6 +209,7 @@
 :hasShippingMarks a owl:ObjectProperty ;
     rdfs:label "has shipping marks" ;
     rdfs:comment "Shipping marks applied to this cargo item or package." ;
+    rdfs:domain :CargoItem ;
     rdfs:range :ShippingMarks .
 
 :hasInsurance a owl:ObjectProperty ;

--- a/ontology-reference-models/derived-ontologies/MMT/current/consignment/consignment.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/consignment/consignment.ttl
@@ -4,6 +4,13 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mmt: <https://www.kairosflow.ai/ont/mmt#> .
+@prefix mmt-doc: <https://www.kairosflow.ai/ont/mmt/documents#> .
+@prefix mmt-equip: <https://www.kairosflow.ai/ont/mmt/equipment#> .
+@prefix mmt-evt: <https://www.kairosflow.ai/ont/mmt/events#> .
+@prefix mmt-loc: <https://www.kairosflow.ai/ont/mmt/locations#> .
+@prefix mmt-party: <https://www.kairosflow.ai/ont/mmt/party#> .
+@prefix mmt-tm: <https://www.kairosflow.ai/ont/mmt/transport-means#> .
 
 # Ontology Metadata
 <https://www.kairosflow.ai/ont/mmt/consignment> a owl:Ontology ;
@@ -14,7 +21,7 @@
     transport routes, legs, and movements. Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -153,12 +160,14 @@
 :hasTransportEquipment a owl:ObjectProperty ;
     rdfs:label "has transport equipment" ;
     rdfs:comment "Relates consignment to equipment used." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-equip:TransportEquipment .
 
 :loadedInEquipment a owl:ObjectProperty ;
     rdfs:label "loaded in equipment" ;
     rdfs:comment "Relates goods to equipment they are loaded in." ;
-    rdfs:domain :GoodsItem .
+    rdfs:domain :GoodsItem ;
+    rdfs:range mmt-equip:TransportEquipment .
 
 :hasRoute a owl:ObjectProperty ;
     rdfs:label "has route" ;
@@ -175,58 +184,74 @@
 :usesTransportMeans a owl:ObjectProperty ;
     rdfs:label "uses transport means" ;
     rdfs:comment "Relates transport leg to vehicle/vessel used." ;
-    rdfs:domain :TransportLeg .
+    rdfs:domain :TransportLeg ;
+    rdfs:range mmt-tm:LogisticsMeansOfTransport .
 
 :departureLocation a owl:ObjectProperty ;
     rdfs:label "departure location" ;
     rdfs:comment "Identifies the departure location." ;
-    rdfs:domain :TransportLeg .
+    rdfs:domain :TransportLeg ;
+    rdfs:range mmt-loc:TransportLocation .
 
 :arrivalLocation a owl:ObjectProperty ;
     rdfs:label "arrival location" ;
     rdfs:comment "Identifies the arrival location." ;
-    rdfs:domain :TransportLeg .
+    rdfs:domain :TransportLeg ;
+    rdfs:range mmt-loc:TransportLocation .
 
 :hasConsignor a owl:ObjectProperty ;
     rdfs:label "has consignor" ;
     rdfs:comment "Identifies the consignor (shipper)." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-party:Consignor .
 
 :hasConsignee a owl:ObjectProperty ;
     rdfs:label "has consignee" ;
     rdfs:comment "Identifies the consignee (receiver)." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-party:Consignee .
 
 :hasCarrier a owl:ObjectProperty ;
     rdfs:label "has carrier" ;
-    rdfs:comment "Identifies the carrier." .
+    rdfs:comment "Identifies the carrier." ;
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-party:Carrier .
 
 :hasFreightForwarder a owl:ObjectProperty ;
     rdfs:label "has freight forwarder" ;
-    rdfs:comment "Identifies the freight forwarder." .
+    rdfs:comment "Identifies the freight forwarder." ;
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-party:FreightForwarder .
 
 :hasNotifyParty a owl:ObjectProperty ;
     rdfs:label "has notify party" ;
-    rdfs:comment "Identifies a notify party." .
+    rdfs:comment "Identifies a notify party." ;
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-party:NotifyParty .
 
 :hasTransportDocument a owl:ObjectProperty ;
     rdfs:label "has transport document" ;
     rdfs:comment "Relates consignment to transport documents." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-doc:TransportDocument .
 
 :hasCustomsDeclaration a owl:ObjectProperty ;
     rdfs:label "has customs declaration" ;
     rdfs:comment "Relates consignment to customs documents." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-doc:CustomsDeclaration .
 
 :hasEvent a owl:ObjectProperty ;
     rdfs:label "has event" ;
-    rdfs:comment "Relates consignment or transport to events." .
+    rdfs:comment "Relates consignment or transport to events." ;
+    rdfs:domain :Consignment ;
+    rdfs:range mmt-evt:TransportEvent .
 
 :hasDangerousGoods a owl:ObjectProperty ;
     rdfs:label "has dangerous goods" ;
     rdfs:comment "Indicates consignment contains dangerous goods." ;
-    rdfs:domain :Consignment .
+    rdfs:domain :Consignment ;
+    rdfs:range mmt:DangerousGoods .
 
 #################################################################
 #    Datatype Properties
@@ -241,11 +266,13 @@
 :masterReferenceNumber a owl:DatatypeProperty ;
     rdfs:label "master reference number" ;
     rdfs:comment "Master transport document number." ;
+    rdfs:domain :MasterConsignment ;
     rdfs:range xsd:string .
 
 :houseReferenceNumber a owl:DatatypeProperty ;
     rdfs:label "house reference number" ;
     rdfs:comment "House transport document number." ;
+    rdfs:domain :HouseConsignment ;
     rdfs:range xsd:string .
 
 :itemSequenceNumber a owl:DatatypeProperty ;
@@ -257,106 +284,127 @@
 :transportMode a owl:DatatypeProperty ;
     rdfs:label "transport mode" ;
     rdfs:comment "Mode of transport: MARITIME, AIR, RAIL, ROAD, INLAND_WATERWAY." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:string .
 
 :modeCode a owl:DatatypeProperty ;
     rdfs:label "mode code" ;
     rdfs:comment "UN/CEFACT transport mode code (1-9)." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:string .
 
 :numberOfPackages a owl:DatatypeProperty ;
     rdfs:label "number of packages" ;
     rdfs:comment "Total number of packages." ;
+    rdfs:domain :ConsignmentItem ;
     rdfs:range xsd:integer .
 
 :packageType a owl:DatatypeProperty ;
     rdfs:label "package type" ;
     rdfs:comment "Type of packaging (e.g., carton, pallet, crate)." ;
+    rdfs:domain :Package ;
     rdfs:range xsd:string .
 
 :packageCode a owl:DatatypeProperty ;
     rdfs:label "package code" ;
     rdfs:comment "UN/CEFACT package type code." ;
+    rdfs:domain :Package ;
     rdfs:range xsd:string .
 
 :grossWeight a owl:DatatypeProperty ;
     rdfs:label "gross weight" ;
     rdfs:comment "Total weight including packaging (kg)." ;
+    rdfs:domain :ConsignmentItem ;
     rdfs:range xsd:decimal .
 
 :netWeight a owl:DatatypeProperty ;
     rdfs:label "net weight" ;
     rdfs:comment "Weight of goods only (kg)." ;
+    rdfs:domain :ConsignmentItem ;
     rdfs:range xsd:decimal .
 
 :volume a owl:DatatypeProperty ;
     rdfs:label "volume" ;
     rdfs:comment "Volume in cubic meters." ;
+    rdfs:domain :ConsignmentItem ;
     rdfs:range xsd:decimal .
 
 :chargeableWeight a owl:DatatypeProperty ;
     rdfs:label "chargeable weight" ;
     rdfs:comment "Weight used for freight calculation." ;
+    rdfs:domain :Consignment ;
     rdfs:range xsd:decimal .
 
 :goodsDescription a owl:DatatypeProperty ;
     rdfs:label "goods description" ;
     rdfs:comment "Description of the goods." ;
+    rdfs:domain :GoodsItem ;
     rdfs:range xsd:string .
 
 :hsCode a owl:DatatypeProperty ;
     rdfs:label "HS code" ;
     rdfs:comment "Harmonized System commodity classification code." ;
+    rdfs:domain :GoodsItem ;
     rdfs:range xsd:string .
 
 :countryOfOrigin a owl:DatatypeProperty ;
     rdfs:label "country of origin" ;
     rdfs:comment "ISO 3166 country code where goods originated." ;
+    rdfs:domain :GoodsItem ;
     rdfs:range xsd:string .
 
 :customsValue a owl:DatatypeProperty ;
     rdfs:label "customs value" ;
     rdfs:comment "Declared value for customs purposes." ;
+    rdfs:domain :Consignment ;
     rdfs:range xsd:decimal .
 
 :currency a owl:DatatypeProperty ;
     rdfs:label "currency" ;
     rdfs:comment "ISO 4217 currency code." ;
+    rdfs:domain :Consignment ;
     rdfs:range xsd:string .
 
 :incoterm a owl:DatatypeProperty ;
     rdfs:label "Incoterm" ;
     rdfs:comment "International Commercial Terms (e.g., FOB, CIF, EXW)." ;
+    rdfs:domain :Consignment ;
     rdfs:range xsd:string .
 
 :freightTerms a owl:DatatypeProperty ;
     rdfs:label "freight terms" ;
     rdfs:comment "Freight payment terms: PREPAID, COLLECT." ;
+    rdfs:domain :Consignment ;
     rdfs:range xsd:string .
 
 :estimatedDepartureTime a owl:DatatypeProperty ;
     rdfs:label "estimated departure time (ETD)" ;
     rdfs:comment "Estimated departure date and time." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:dateTime .
 
 :actualDepartureTime a owl:DatatypeProperty ;
     rdfs:label "actual departure time (ATD)" ;
     rdfs:comment "Actual departure date and time." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:dateTime .
 
 :estimatedArrivalTime a owl:DatatypeProperty ;
     rdfs:label "estimated arrival time (ETA)" ;
     rdfs:comment "Estimated arrival date and time." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:dateTime .
 
 :actualArrivalTime a owl:DatatypeProperty ;
     rdfs:label "actual arrival time (ATA)" ;
     rdfs:comment "Actual arrival date and time." ;
+    rdfs:domain :TransportMovement ;
     rdfs:range xsd:dateTime .
 
 :isHazardous a owl:DatatypeProperty ;
     rdfs:label "is hazardous" ;
     rdfs:comment "Indicates if goods are dangerous/hazardous." ;
+    rdfs:domain :GoodsItem ;
     rdfs:range xsd:boolean .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/MMT/current/documents/documents.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/documents/documents.ttl
@@ -15,7 +15,7 @@
     and dangerous goods declarations. Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -177,6 +177,7 @@
 :hasCertificate a owl:ObjectProperty ;
     rdfs:label "has certificate" ;
     rdfs:comment "Product certificate associated with this document." ;
+    rdfs:domain :TransportDocument ;
     rdfs:range :ProductCertificate .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/MMT/current/equipment/equipment.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/equipment/equipment.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mmt-evt: <https://www.kairosflow.ai/ont/mmt/events#> .
 
 # Ontology Metadata
 <https://www.kairosflow.ai/ont/mmt/equipment> a owl:Ontology ;
@@ -14,7 +15,7 @@
     trailers, and equipment properties. Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -83,6 +84,7 @@
 :involvesEquipment a owl:ObjectProperty ;
     rdfs:label "involves equipment" ;
     rdfs:comment "Relates event to equipment involved." ;
+    rdfs:domain mmt-evt:TransportEvent ;
     rdfs:range :TransportEquipment .
 
 #################################################################
@@ -116,11 +118,14 @@
 :sealNumber a owl:DatatypeProperty ;
     rdfs:label "seal number" ;
     rdfs:comment "Security seal identifier." ;
+    rdfs:domain :Seal ;
     rdfs:range xsd:string .
 
 :sealType a owl:DatatypeProperty ;
     rdfs:label "seal type" ;
-    rdfs:comment "Type of seal: CARRIER, CUSTOMS, SHIPPER." .
+    rdfs:comment "Type of seal: CARRIER, CUSTOMS, SHIPPER." ;
+    rdfs:domain :Seal ;
+    rdfs:range xsd:string .
 
 #################################################################
 #    Temperature Instruction Class (UN/CEFACT RABIE v101)
@@ -169,11 +174,13 @@
 :minimumTemperature a owl:DatatypeProperty ;
     rdfs:label "minimum temperature" ;
     rdfs:comment "Minimum allowed temperature in Celsius." ;
+    rdfs:domain :ReeferContainer ;
     rdfs:range xsd:decimal .
 
 :maximumTemperature a owl:DatatypeProperty ;
     rdfs:label "maximum temperature" ;
     rdfs:comment "Maximum allowed temperature in Celsius." ;
+    rdfs:domain :ReeferContainer ;
     rdfs:range xsd:decimal .
 
 :isShipperOwned a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/MMT/current/inland-transport/inland-transport.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/inland-transport/inland-transport.ttl
@@ -124,7 +124,9 @@
 
 :inlandMode a owl:DatatypeProperty ;
     rdfs:label "inland mode" ;
-    rdfs:comment "Inland transport mode: RAIL, BARGE, ROAD." .
+    rdfs:comment "Inland transport mode: RAIL, BARGE, ROAD." ;
+    rdfs:domain :InlandLeg ;
+    rdfs:range xsd:string .
 
 :inlandCarrierCode a owl:DatatypeProperty ;
     rdfs:label "inland carrier code" ;

--- a/ontology-reference-models/derived-ontologies/MMT/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/locations/locations.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mmt-evt: <https://www.kairosflow.ai/ont/mmt/events#> .
 
 # Ontology Metadata
 <https://www.kairosflow.ai/ont/mmt/locations> a owl:Ontology ;
@@ -15,7 +16,7 @@
     Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -107,6 +108,7 @@
 :occursAtLocation a owl:ObjectProperty ;
     rdfs:label "occurs at location" ;
     rdfs:comment "Relates event to location where it occurred." ;
+    rdfs:domain mmt-evt:TransportEvent ;
     rdfs:range :Location .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/MMT/current/mmt.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/mmt.ttl
@@ -161,9 +161,11 @@
 :flashPoint a owl:DatatypeProperty ;
     rdfs:label "flash point" ;
     rdfs:comment "Flash point temperature in Celsius for flammable goods." ;
+    rdfs:domain :DangerousGoods ;
     rdfs:range xsd:decimal .
 
 :emergencyContactNumber a owl:DatatypeProperty ;
     rdfs:label "emergency contact number" ;
     rdfs:comment "24-hour emergency phone number for dangerous goods." ;
+    rdfs:domain :DangerousGoods ;
     rdfs:range xsd:string .

--- a/ontology-reference-models/derived-ontologies/MMT/current/route-network/route-network.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/route-network/route-network.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mmt-evt: <https://www.kairosflow.ai/ont/mmt/events#> .
 
 # Ontology Metadata
 <https://www.kairosflow.ai/ont/mmt/route-network> a owl:Ontology ;
@@ -14,7 +15,7 @@
     Based on UN/CEFACT MMT Reference Data Model (TransportRouteType, TransportServiceType).""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model v1.0 (RABIE v101)" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -37,7 +38,8 @@
 :hasItineraryStop a owl:ObjectProperty ;
     rdfs:label "has itinerary stop" ;
     rdfs:comment "An itinerary stop event along this route." ;
-    rdfs:domain :Route .
+    rdfs:domain :Route ;
+    rdfs:range mmt-evt:TransportEvent .
 
 #################################################################
 #    Datatype Properties

--- a/ontology-reference-models/derived-ontologies/MMT/current/transport-means/transport-means.ttl
+++ b/ontology-reference-models/derived-ontologies/MMT/current/transport-means/transport-means.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix mmt-evt: <https://www.kairosflow.ai/ont/mmt/events#> .
 
 # Ontology Metadata
 <https://www.kairosflow.ai/ont/mmt/transport-means> a owl:Ontology ;
@@ -14,7 +15,7 @@
     capacity. Based on UN/CEFACT MMT Reference Data Model.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-01-06"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
     dcterms:source "UN/CEFACT Multi-Modal Transport Reference Data Model" ;
     rdfs:seeAlso <https://unece.org/trade/uncefact/rdm> .
@@ -71,6 +72,7 @@
 :involvesTransportMeans a owl:ObjectProperty ;
     rdfs:label "involves transport means" ;
     rdfs:comment "Relates event to vehicle/vessel involved." ;
+    rdfs:domain mmt-evt:TransportEvent ;
     rdfs:range :LogisticsMeansOfTransport .
 
 #################################################################
@@ -92,6 +94,7 @@
 :voyageNumber a owl:DatatypeProperty ;
     rdfs:label "voyage number" ;
     rdfs:comment "Voyage or sailing reference." ;
+    rdfs:domain :Vessel ;
     rdfs:range xsd:string .
 
 #################################################################
@@ -136,4 +139,5 @@
 :carrierCode a owl:DatatypeProperty ;
     rdfs:label "carrier code" ;
     rdfs:comment "SCAC, IATA, or other carrier identifier." ;
+    rdfs:domain :LogisticsMeansOfTransport ;
     rdfs:range xsd:string .

--- a/ontology-reference-models/derived-ontologies/Sustainability/current/carbon/carbon.ttl
+++ b/ontology-reference-models/derived-ontologies/Sustainability/current/carbon/carbon.ttl
@@ -4,6 +4,9 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix vessel: <https://www.kairosflow.ai/ont/imo/vessel-registry#> .
+@prefix pc: <https://www.kairosflow.ai/ont/imo/port-call#> .
+@prefix party: <https://www.kairosflow.ai/ont/imo/party#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,11 +14,14 @@
     dcterms:description "Carbon emissions, greenhouse gas accounting, and environmental compliance for transport and logistics based on ISO 14083:2023 and the GLEC Framework." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "ISO 14083:2023, GLEC Framework, EU MRV Regulation, IMO DCS, EU ETS Maritime" ;
     rdfs:seeAlso <https://www.iso.org/standard/78864.html> ,
-                 <https://www.smartfreightcentre.org/en/how-to-implement-glec-framework/> .
+                 <https://www.smartfreightcentre.org/en/how-to-implement-glec-framework/> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry#> ,
+                <https://www.kairosflow.ai/ont/imo/port-call#> ,
+                <https://www.kairosflow.ai/ont/imo/party#> .
 
 #################################################################
 #    Emission Classes
@@ -200,41 +206,52 @@
 :hasCO2Intensity a owl:ObjectProperty ;
     rdfs:label "has CO2 intensity" ;
     rdfs:comment "Relates an entity to its CO2 intensity metric." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( vessel:Vessel pc:Voyage )
+    ] ;
     rdfs:range :CO2Intensity .
 
 :hasCarbonFootprint a owl:ObjectProperty ;
     rdfs:label "has carbon footprint" ;
     rdfs:comment "Relates an entity to its carbon footprint." ;
+    rdfs:domain pc:Voyage ;
     rdfs:range :CarbonFootprint .
 
 :hasEmissionReport a owl:ObjectProperty ;
     rdfs:label "has emission report" ;
     rdfs:comment "Relates an entity to its emission report." ;
+    rdfs:domain vessel:Vessel ;
     rdfs:range :EmissionReport .
 
 :hasCIIRating a owl:ObjectProperty ;
     rdfs:label "has CII rating" ;
     rdfs:comment "Relates a vessel to its CII rating." ;
+    rdfs:domain vessel:Vessel ;
     rdfs:range :CIIRating .
 
 :hasEEXICompliance a owl:ObjectProperty ;
     rdfs:label "has EEXI compliance" ;
     rdfs:comment "Relates a vessel to its EEXI compliance status." ;
+    rdfs:domain vessel:Vessel ;
     rdfs:range :EEXICompliance .
 
 :hasEUETSAllowance a owl:ObjectProperty ;
     rdfs:label "has EU ETS allowance" ;
     rdfs:comment "Relates an entity to its EU ETS allowance." ;
+    rdfs:domain vessel:Vessel ;
     rdfs:range :EUETSAllowance .
 
 :hasCarbonOffset a owl:ObjectProperty ;
     rdfs:label "has carbon offset" ;
     rdfs:comment "Relates an entity to a carbon offset credit." ;
+    rdfs:domain party:MaritimeParty ;
     rdfs:range :CarbonOffset .
 
 :hasModalShiftMetric a owl:ObjectProperty ;
     rdfs:label "has modal shift metric" ;
     rdfs:comment "Relates an entity to a modal shift metric." ;
+    rdfs:domain pc:Voyage ;
     rdfs:range :ModalShiftMetric .
 
 :calculatedUsing a owl:ObjectProperty ;

--- a/ontology-reference-models/derived-ontologies/Sustainability/current/energy/energy.ttl
+++ b/ontology-reference-models/derived-ontologies/Sustainability/current/energy/energy.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix vessel: <https://www.kairosflow.ai/ont/imo/vessel-registry#> .
+@prefix pc: <https://www.kairosflow.ai/ont/imo/port-call#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,10 +13,12 @@
     dcterms:description "Energy consumption, fuel types, and energy efficiency for transport and logistics based on EU MRV Regulation and IMO DCS." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "ISO 14083:2023, GLEC Framework, EU MRV Regulation, IMO DCS, EU ETS Maritime" ;
-    rdfs:seeAlso <https://www.iso.org/standard/78864.html> .
+    rdfs:seeAlso <https://www.iso.org/standard/78864.html> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry#> ,
+                <https://www.kairosflow.ai/ont/imo/port-call#> .
 
 #################################################################
 #    Energy Consumption and Fuel Classes
@@ -152,6 +156,10 @@
 :hasEnergyConsumption a owl:ObjectProperty ;
     rdfs:label "has energy consumption" ;
     rdfs:comment "Relates an entity to its energy consumption record." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( vessel:Vessel pc:Voyage )
+    ] ;
     rdfs:range :EnergyConsumption .
 
 :usesFuelType a owl:ObjectProperty ;
@@ -169,31 +177,43 @@
 :hasShorepower a owl:ObjectProperty ;
     rdfs:label "has shorepower" ;
     rdfs:comment "Relates an entity to a shorepower connection." ;
+    rdfs:domain pc:BerthStay ;
     rdfs:range :Shorepower .
 
 :hasEnergyEfficiency a owl:ObjectProperty ;
     rdfs:label "has energy efficiency" ;
     rdfs:comment "Relates an entity to its energy efficiency metric." ;
+    rdfs:domain vessel:Vessel ;
     rdfs:range :EnergyEfficiency .
 
 :hasFuelOilConsumption a owl:ObjectProperty ;
     rdfs:label "has fuel oil consumption" ;
     rdfs:comment "Relates an entity to a fuel oil consumption record." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( vessel:Vessel pc:Voyage )
+    ] ;
     rdfs:range :FuelOilConsumption .
 
 :hasBunkerDeliveryNote a owl:ObjectProperty ;
     rdfs:label "has bunker delivery note" ;
     rdfs:comment "Relates an entity to a bunker delivery note." ;
+    rdfs:domain pc:BunkeringOperation ;
     rdfs:range :BunkerDeliveryNote .
 
 :hasEnergyPerformanceIndicator a owl:ObjectProperty ;
     rdfs:label "has energy performance indicator" ;
     rdfs:comment "Relates an entity to an energy performance indicator." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( vessel:Vessel pc:Voyage )
+    ] ;
     rdfs:range :EnergyPerformanceIndicator .
 
 :suppliedByRenewable a owl:ObjectProperty ;
     rdfs:label "supplied by renewable" ;
     rdfs:comment "Relates an entity to its renewable energy source." ;
+    rdfs:domain :EnergyConsumption ;
     rdfs:range :RenewableEnergy .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/TIC/current/automotive-services/automotive-services.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/automotive-services/automotive-services.ttl
@@ -1,4 +1,5 @@
 @prefix : <https://www.kairosflow.ai/ont/tic/automotive-services#> .
+@prefix tic-party: <https://www.kairosflow.ai/ont/tic/party#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -15,7 +16,7 @@
     body repair, release status, and damage reporting.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -172,7 +173,8 @@
 :performedBy a owl:ObjectProperty ;
     rdfs:label "performed by" ;
     rdfs:comment "Links a vehicle service to the party who performed it." ;
-    rdfs:domain :VehicleService .
+    rdfs:domain :VehicleService ;
+    rdfs:range tic-party:TerminalParty .
 
 #################################################################
 #    Datatype Properties

--- a/ontology-reference-models/derived-ontologies/TIC/current/events/events.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/events/events.ttl
@@ -1,4 +1,9 @@
 @prefix : <https://www.kairosflow.ai/ont/tic/events#> .
+@prefix tic-auto: <https://www.kairosflow.ai/ont/tic/automotive-services#> .
+@prefix tic-infra: <https://www.kairosflow.ai/ont/tic/terminal-infrastructure#> .
+@prefix tic-loc: <https://www.kairosflow.ai/ont/tic/locations#> .
+@prefix tic-ops: <https://www.kairosflow.ai/ont/tic/handling-operations#> .
+@prefix tic-party: <https://www.kairosflow.ai/ont/tic/party#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -14,7 +19,7 @@
     vessel loading and discharging, stacking, service completion, damage detection, and inspections.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -125,27 +130,35 @@
 :fromLocation a owl:ObjectProperty ;
     rdfs:label "from location" ;
     rdfs:comment "The origin location of a move event." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range tic-loc:TerminalLocation .
 
 :toLocation a owl:ObjectProperty ;
     rdfs:label "to location" ;
     rdfs:comment "The destination location of a move event." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range tic-loc:TerminalLocation .
 
 :involvesCargo a owl:ObjectProperty ;
     rdfs:label "involves cargo" ;
     rdfs:comment "Links an event to the cargo unit or vehicle it pertains to." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range [
+        a owl:Class ;
+        owl:unionOf ( tic-ops:CargoVisit tic-auto:VehicleUnit )
+    ] .
 
 :involvedEquipment a owl:ObjectProperty ;
     rdfs:label "involved equipment" ;
     rdfs:comment "Links an event to the handling equipment used." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range tic-infra:TerminalEquipment .
 
 :recordedBy a owl:ObjectProperty ;
     rdfs:label "recorded by" ;
     rdfs:comment "Links an event to the party or system that recorded it." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range tic-party:TerminalParty .
 
 :triggeredBy a owl:ObjectProperty ;
     rdfs:label "triggered by" ;
@@ -156,7 +169,8 @@
 :relatedVesselCall a owl:ObjectProperty ;
     rdfs:label "related vessel call" ;
     rdfs:comment "Links a vessel load/discharge event to its vessel call reference." ;
-    rdfs:domain :TerminalEvent .
+    rdfs:domain :TerminalEvent ;
+    rdfs:range tic-ops:CarrierVisit .
 
 #################################################################
 #    Datatype Properties
@@ -189,21 +203,34 @@
 :vesselCallReference a owl:DatatypeProperty ;
     rdfs:label "vessel call reference" ;
     rdfs:comment "Identifier of the vessel call (port visit) associated with the event." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :VesselLoadEvent :VesselDischargeEvent )
+    ] ;
     rdfs:range xsd:string .
 
 :sealNumber a owl:DatatypeProperty ;
     rdfs:label "seal number" ;
     rdfs:comment "Seal identifier verified during gate events." ;
+    rdfs:domain :GateInEvent ;
     rdfs:range xsd:string .
 
 :truckLicensePlate a owl:DatatypeProperty ;
     rdfs:label "truck license plate" ;
     rdfs:comment "License plate of the truck involved in a gate event." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :GateInEvent :GateOutEvent )
+    ] ;
     rdfs:range xsd:string .
 
 :stowagePosition a owl:DatatypeProperty ;
     rdfs:label "stowage position" ;
     rdfs:comment "Vessel stowage position (bay-row-tier) for load/discharge events." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :VesselLoadEvent :VesselDischargeEvent )
+    ] ;
     rdfs:range xsd:string .
 
 :inspectionOutcome a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/TIC/current/handling-operations/handling-operations.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/handling-operations/handling-operations.ttl
@@ -1,4 +1,6 @@
 @prefix : <https://www.kairosflow.ai/ont/tic/handling-operations#> .
+@prefix tic-infra: <https://www.kairosflow.ai/ont/tic/terminal-infrastructure#> .
+@prefix tic-loc: <https://www.kairosflow.ai/ont/tic/locations#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -14,7 +16,7 @@
     job instructions, and move types (load, discharge, lift, horizontal).""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -137,11 +139,19 @@
 :hasMove a owl:ObjectProperty ;
     rdfs:label "has move" ;
     rdfs:comment "Links a cycle or cargo visit to an individual move." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Cycle :CargoVisit )
+    ] ;
     rdfs:range :Move .
 
 :hasCycle a owl:ObjectProperty ;
     rdfs:label "has cycle" ;
     rdfs:comment "Links a carrier visit or cargo visit to a cycle performed during it." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :CarrierVisit :CargoVisit )
+    ] ;
     rdfs:range :Cycle .
 
 :executesInstruction a owl:ObjectProperty ;
@@ -153,17 +163,20 @@
 :instructionOrigin a owl:ObjectProperty ;
     rdfs:label "instruction origin" ;
     rdfs:comment "The origin location for a job instruction." ;
-    rdfs:domain :JobInstruction .
+    rdfs:domain :JobInstruction ;
+    rdfs:range tic-loc:TerminalLocation .
 
 :instructionDestination a owl:ObjectProperty ;
     rdfs:label "instruction destination" ;
     rdfs:comment "The destination location for a job instruction." ;
-    rdfs:domain :JobInstruction .
+    rdfs:domain :JobInstruction ;
+    rdfs:range tic-loc:TerminalLocation .
 
 :performedBy a owl:ObjectProperty ;
     rdfs:label "performed by" ;
     rdfs:comment "Links a move or cycle to the CHE that performed it." ;
-    rdfs:domain :Move .
+    rdfs:domain :Move ;
+    rdfs:range tic-infra:TerminalEquipment .
 
 :followsMove a owl:ObjectProperty ;
     rdfs:label "follows move" ;
@@ -232,6 +245,10 @@
 :moveCount a owl:DatatypeProperty ;
     rdfs:label "move count" ;
     rdfs:comment "Total number of moves in a cycle or carrier visit." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Cycle :CarrierVisit )
+    ] ;
     rdfs:range xsd:integer .
 
 :instructionPriority a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/TIC/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/locations/locations.ttl
@@ -14,7 +14,7 @@
     positions, gate lanes, quay side areas, reefer plugs, rail sidings, and barge quays.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -135,6 +135,10 @@
 :withinTerminal a owl:ObjectProperty ;
     rdfs:label "within terminal" ;
     rdfs:comment "Links a location to the terminal it belongs to." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Berth :YardPosition :GateLane :QuaySide :ReeferPlug :RailSiding :BargeQuay )
+    ] ;
     rdfs:range :Terminal .
 
 :hasLocation a owl:ObjectProperty ;

--- a/ontology-reference-models/derived-ontologies/TIC/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/party/party.ttl
@@ -1,4 +1,5 @@
 @prefix : <https://www.kairosflow.ai/ont/tic/party#> .
+@prefix tic-loc: <https://www.kairosflow.ai/ont/tic/locations#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -14,7 +15,7 @@
     terminal operators and stevedoring companies.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -57,7 +58,8 @@
 :operatesTerminal a owl:ObjectProperty ;
     rdfs:label "operates terminal" ;
     rdfs:comment "Links a terminal operator to the terminal it manages." ;
-    rdfs:domain :TerminalOperator .
+    rdfs:domain :TerminalOperator ;
+    rdfs:range tic-loc:Terminal .
 
 :employedBy a owl:ObjectProperty ;
     rdfs:label "employed by" ;

--- a/ontology-reference-models/derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl
@@ -1,4 +1,5 @@
 @prefix : <https://www.kairosflow.ai/ont/tic/terminal-infrastructure#> .
+@prefix tic-loc: <https://www.kairosflow.ai/ont/tic/locations#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@@ -15,7 +16,7 @@
     yard cranes, reach stackers, and terminal tractors.""" ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-07-15"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> .
@@ -133,6 +134,10 @@
 :belongsToTerminal a owl:ObjectProperty ;
     rdfs:label "belongs to terminal" ;
     rdfs:comment "Links an infrastructure element to its parent terminal." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Berth :YardArea :Gate :StorageZone :RailHead :BargeConnection )
+    ] ;
     rdfs:range :Terminal .
 
 :hasBerth a owl:ObjectProperty ;
@@ -157,11 +162,16 @@
 :hasGateLane a owl:ObjectProperty ;
     rdfs:label "has gate lane" ;
     rdfs:comment "Links a gate to an individual lane." ;
-    rdfs:domain :Gate .
+    rdfs:domain :Gate ;
+    rdfs:range tic-loc:GateLane .
 
 :hasStorageZone a owl:ObjectProperty ;
     rdfs:label "has storage zone" ;
     rdfs:comment "Links a terminal or yard area to a storage zone." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Terminal :YardArea )
+    ] ;
     rdfs:range :StorageZone .
 
 :hasRailHead a owl:ObjectProperty ;
@@ -179,6 +189,10 @@
 :assignedEquipment a owl:ObjectProperty ;
     rdfs:label "assigned equipment" ;
     rdfs:comment "Links a terminal area to equipment assigned for operations." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Berth :YardArea :Gate :StorageZone :RailHead :BargeConnection )
+    ] ;
     rdfs:range :TerminalEquipment .
 
 #################################################################
@@ -230,6 +244,10 @@
 :stackingCapacity a owl:DatatypeProperty ;
     rdfs:label "stacking capacity" ;
     rdfs:comment "Maximum number of container tiers a yard area or crane can handle." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :YardArea :YardCrane )
+    ] ;
     rdfs:range xsd:integer .
 
 :gateCapacityTrucksPerHour a owl:DatatypeProperty ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/documents/documents.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/documents/documents.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,7 +12,7 @@
     dcterms:description "Customs and trade documents including declarations, permits, transit documents, and international trade carnets based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "WCO Data Model 3.10.0, eFTI Regulation (EU) 2020/1056" ;
     rdfs:seeAlso <https://www.wcoomd.org/datamodel> .
@@ -134,36 +135,43 @@
 :hasCustomsDocument a owl:ObjectProperty ;
     rdfs:label "has customs document" ;
     rdfs:comment "Links an entity to its associated customs declaration document." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :CustomsDeclarationDocument .
 
 :hasTransitDocument a owl:ObjectProperty ;
     rdfs:label "has transit document" ;
     rdfs:comment "Links an entity to its associated transit document." ;
+    rdfs:domain wco-customs:TransitDeclaration ;
     rdfs:range :TransitDocument .
 
 :hasImportPermitDocument a owl:ObjectProperty ;
     rdfs:label "has import permit document" ;
     rdfs:comment "Links an entity to its associated import permit document." ;
+    rdfs:domain wco-customs:ImportDeclaration ;
     rdfs:range :ImportPermitDocument .
 
 :hasExportLicenseDocument a owl:ObjectProperty ;
     rdfs:label "has export license document" ;
     rdfs:comment "Links an entity to its associated export license document." ;
+    rdfs:domain wco-customs:ExportDeclaration ;
     rdfs:range :ExportLicenseDocument .
 
 :hasOriginDocument a owl:ObjectProperty ;
     rdfs:label "has origin document" ;
     rdfs:comment "Links an entity to its associated preferential origin document." ;
+    rdfs:domain wco-customs:PreferenceClaim ;
     rdfs:range :PreferentialOriginDoc .
 
 :accompaniedByCarnet a owl:ObjectProperty ;
     rdfs:label "accompanied by carnet" ;
     rdfs:comment "Links an entity to an accompanying ATA Carnet." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :ATACarnet .
 
 :coveredByTIRCarnet a owl:ObjectProperty ;
     rdfs:label "covered by TIR carnet" ;
     rdfs:comment "Links an entity to a covering TIR Carnet." ;
+    rdfs:domain wco-customs:TransitDeclaration ;
     rdfs:range :TIRCarnet .
 
 :supersedes a owl:ObjectProperty ;
@@ -251,4 +259,8 @@
 :numberOfPages a owl:DatatypeProperty ;
     rdfs:label "number of pages" ;
     rdfs:comment "Total number of pages in the document." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :CustomsDeclarationDocument :ImportPermitDocument :ExportLicenseDocument :PreferentialOriginDoc :ATACarnet :TIRCarnet )
+    ] ;
     rdfs:range xsd:integer .

--- a/ontology-reference-models/derived-ontologies/WCO/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/locations/locations.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,7 +12,7 @@
     dcterms:description "Customs locations, border crossings, bonded facilities, and controlled areas based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "WCO Data Model 3.10.0, eFTI Regulation (EU) 2020/1056" ;
     rdfs:seeAlso <https://www.wcoomd.org/datamodel> .
@@ -78,31 +79,37 @@
 :locatedAtCustomsOffice a owl:ObjectProperty ;
     rdfs:label "located at customs office" ;
     rdfs:comment "The customs office associated with this entity." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :CustomsOffice .
 
 :hasBorderCrossing a owl:ObjectProperty ;
     rdfs:label "has border crossing" ;
     rdfs:comment "The border crossing point associated with this entity." ;
+    rdfs:domain wco-customs:TransitDeclaration ;
     rdfs:range :BorderCrossing .
 
 :storedInBondedWarehouse a owl:ObjectProperty ;
     rdfs:label "stored in bonded warehouse" ;
     rdfs:comment "The bonded warehouse where goods are stored." ;
+    rdfs:domain wco-customs:ImportDeclaration ;
     rdfs:range :BondedWarehouse .
 
 :locatedInFreeZone a owl:ObjectProperty ;
     rdfs:label "located in free zone" ;
     rdfs:comment "The free zone in which this entity is located." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :FreeZone .
 
 :withinCustomsControlledArea a owl:ObjectProperty ;
     rdfs:label "within customs controlled area" ;
     rdfs:comment "The customs controlled area in which this entity is situated." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :CustomsControlledArea .
 
 :hasDesignatedExportPlace a owl:ObjectProperty ;
     rdfs:label "has designated export place" ;
     rdfs:comment "The designated export place associated with this entity." ;
+    rdfs:domain wco-customs:ExportDeclaration ;
     rdfs:range :DesignatedExportPlace .
 
 :supervisedBy a owl:ObjectProperty ;
@@ -172,9 +179,17 @@
 :latitude a owl:DatatypeProperty ;
     rdfs:label "latitude" ;
     rdfs:comment "Geographic latitude coordinate in decimal degrees." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :CustomsOffice :BorderCrossing :BondedWarehouse :FreeZone :CustomsControlledArea :DesignatedExportPlace )
+    ] ;
     rdfs:range xsd:decimal .
 
 :longitude a owl:DatatypeProperty ;
     rdfs:label "longitude" ;
     rdfs:comment "Geographic longitude coordinate in decimal degrees." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :CustomsOffice :BorderCrossing :BondedWarehouse :FreeZone :CustomsControlledArea :DesignatedExportPlace )
+    ] ;
     rdfs:range xsd:decimal .

--- a/ontology-reference-models/derived-ontologies/WCO/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/party/party.ttl
@@ -4,6 +4,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,7 +12,7 @@
     dcterms:description "Party roles in customs processes including declarants, authorities, brokers, and traders based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "WCO Data Model 3.10.0, eFTI Regulation (EU) 2020/1056" ;
     rdfs:seeAlso <https://www.wcoomd.org/datamodel> .
@@ -110,41 +111,58 @@
 :actsAsDeclarant a owl:ObjectProperty ;
     rdfs:label "acts as declarant" ;
     rdfs:comment "Relates a party to the Declarant role it fulfils." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Importer :Exporter :CustomsBroker :FreightAgent :AEOHolder :GuaranteeProvider )
+    ] ;
     rdfs:range :Declarant .
 
 :regulatedBy a owl:ObjectProperty ;
     rdfs:label "regulated by" ;
     rdfs:comment "Relates a party to the Customs Authority that regulates it." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Declarant :CustomsBroker :Importer :Exporter :AEOHolder :FreightAgent :GuaranteeProvider )
+    ] ;
     rdfs:range :CustomsAuthority .
 
 :representedByBroker a owl:ObjectProperty ;
     rdfs:label "represented by broker" ;
     rdfs:comment "Relates a party to the Customs Broker representing it." ;
+    rdfs:domain [
+        a owl:Class ;
+        owl:unionOf ( :Declarant :Importer :Exporter :AEOHolder :FreightAgent :GuaranteeProvider )
+    ] ;
     rdfs:range :CustomsBroker .
 
 :hasImporter a owl:ObjectProperty ;
     rdfs:label "has importer" ;
     rdfs:comment "Relates a customs transaction to its Importer." ;
+    rdfs:domain wco-customs:ImportDeclaration ;
     rdfs:range :Importer .
 
 :hasExporter a owl:ObjectProperty ;
     rdfs:label "has exporter" ;
     rdfs:comment "Relates a customs transaction to its Exporter." ;
+    rdfs:domain wco-customs:ExportDeclaration ;
     rdfs:range :Exporter .
 
 :hasAEOHolder a owl:ObjectProperty ;
     rdfs:label "has AEO holder" ;
     rdfs:comment "Relates a customs transaction to a party with AEO status." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :AEOHolder .
 
 :hasFreightAgent a owl:ObjectProperty ;
     rdfs:label "has freight agent" ;
     rdfs:comment "Relates a customs transaction to a Freight Agent." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :FreightAgent .
 
 :hasGuaranteeProvider a owl:ObjectProperty ;
     rdfs:label "has guarantee provider" ;
     rdfs:comment "Relates a customs obligation to a Guarantee Provider." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :GuaranteeProvider .
 
 #################################################################

--- a/ontology-reference-models/derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl
@@ -4,6 +4,8 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
+@prefix wco-party: <https://www.kairosflow.ai/ont/wco/party#> .
 
 # Ontology Metadata
 : a owl:Ontology ;
@@ -11,7 +13,7 @@
     dcterms:description "Trade facilitation certificates, permits, and trusted trader programmes based on the WCO Data Model 3.10.0 and eFTI Regulation." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-16"^^xsd:date ;
-    dcterms:modified "2026-05-16"^^xsd:date ;
+    dcterms:modified "2026-05-21"^^xsd:date ;
     owl:versionInfo "1.1.0" ;
     dcterms:source "WCO Data Model 3.10.0, eFTI Regulation (EU) 2020/1056" ;
     rdfs:seeAlso <https://www.wcoomd.org/datamodel> .
@@ -122,36 +124,43 @@
 :hasCertificate a owl:ObjectProperty ;
     rdfs:label "has certificate" ;
     rdfs:comment "Links an entity to a trade facilitation certificate." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :Certificate .
 
 :hasLicense a owl:ObjectProperty ;
     rdfs:label "has license" ;
     rdfs:comment "Links an entity to a trade license or authorization." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :License .
 
 :hasAEOCertification a owl:ObjectProperty ;
     rdfs:label "has AEO certification" ;
     rdfs:comment "Links an entity to an Authorised Economic Operator certification." ;
+    rdfs:domain wco-party:AEOHolder ;
     rdfs:range :AEOCertification .
 
 :haseFTIRecord a owl:ObjectProperty ;
     rdfs:label "has eFTI record" ;
     rdfs:comment "Links an entity to an electronic freight transport information record." ;
+    rdfs:domain wco-customs:Filing ;
     rdfs:range :eFTIRecord .
 
 :hasTrustedTrader a owl:ObjectProperty ;
     rdfs:label "has trusted trader" ;
     rdfs:comment "Links an entity to a recognized trusted trader." ;
+    rdfs:domain wco-customs:CustomsDeclaration ;
     rdfs:range :TrustedTrader .
 
 :hasSingleWindow a owl:ObjectProperty ;
     rdfs:label "has single window" ;
     rdfs:comment "Links an entity to a Single Window environment." ;
+    rdfs:domain wco-customs:Filing ;
     rdfs:range :SingleWindow .
 
 :hasTradeAgreementReference a owl:ObjectProperty ;
     rdfs:label "has trade agreement reference" ;
     rdfs:comment "Links an entity to a trade agreement reference." ;
+    rdfs:domain wco-customs:PreferenceClaim ;
     rdfs:range :TradeAgreementReference .
 
 :issuedUnder a owl:ObjectProperty ;

--- a/scripts/validate_structure.py
+++ b/scripts/validate_structure.py
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2026 Cnext.eu
 #!/usr/bin/env python3
 """Validate repository structure conventions for Kairos ontology reference models.
 
@@ -36,6 +38,12 @@ OWL_ONTOLOGY_RE = re.compile(r'\ba\s+owl:Ontology\b')
 OWL_IMPORTS_RE = re.compile(r'owl:imports\s')
 NAMESPACE_ROOT_RE = re.compile(r'@prefix\s+:\s+<https://www\.kairosflow\.ai/ont/([^/>]+)#>\s*\.')
 NAMESPACE_MODULE_RE = re.compile(r'@prefix\s+:\s+<https://www\.kairosflow\.ai/ont/([^/>]+)/([^/>]+)#>\s*\.')
+PROPERTY_START_RE = re.compile(
+    r'^\s*(?P<property>\S+)\s+a\s+owl:(?P<property_type>ObjectProperty|DatatypeProperty)\s*;\s*$'
+)
+BLOCK_END_RE = re.compile(r'\s\.\s*$')
+RDFS_DOMAIN_RE = re.compile(r'\brdfs:domain\b')
+RDFS_RANGE_RE = re.compile(r'\brdfs:range\b')
 
 
 class ValidationResult:
@@ -111,7 +119,7 @@ def find_domain_subfolders(folder: Path):
     content_dir = get_content_dir(folder)
     return sorted(
         d for d in content_dir.iterdir()
-        if d.is_dir() and not d.name.startswith(".") and d.name not in ("archive",)
+        if d.is_dir() and not d.name.startswith(".") and d.name not in ("archive", "extensions")
     )
 
 
@@ -262,6 +270,74 @@ def validate_ontology(folder: Path, verbose: bool) -> ValidationResult:
     return r
 
 
+def validate_property_completeness(folder: Path, verbose: bool) -> ValidationResult:
+    """Validate that property definitions include rdfs:domain and rdfs:range."""
+    r = ValidationResult()
+    content_dir = get_content_dir(folder)
+    ttl_files = sorted(content_dir.rglob("*.ttl"))
+
+    r.messages.append("\n── Property Completeness ──")
+
+    for ttl_file in ttl_files:
+        if "archive" in ttl_file.relative_to(folder).parts:
+            continue
+
+        content = ttl_file.read_text(encoding="utf-8")
+        lines = content.splitlines()
+        property_blocks = []
+        index = 0
+
+        while index < len(lines):
+            match = PROPERTY_START_RE.match(lines[index])
+            if not match:
+                index += 1
+                continue
+
+            block_lines = [lines[index]]
+            index += 1
+            while index < len(lines):
+                block_lines.append(lines[index])
+                if BLOCK_END_RE.search(lines[index]):
+                    break
+                index += 1
+
+            property_blocks.append(
+                (match.group("property"), match.group("property_type"), "\n".join(block_lines))
+            )
+            index += 1
+
+        if not property_blocks:
+            continue
+
+        ttl_rel = ttl_file.relative_to(ONTOLOGY_ROOT)
+        r.ok(
+            f"{ttl_rel}: checked {len(property_blocks)} property definition(s)",
+            verbose,
+            is_verbose=True,
+        )
+
+        for property_name, property_type, block in property_blocks:
+            if RDFS_DOMAIN_RE.search(block):
+                r.ok(
+                    f"{ttl_rel}: {property_name} ({property_type}) has rdfs:domain",
+                    verbose,
+                    is_verbose=True,
+                )
+            else:
+                r.fail(f"{ttl_rel}: {property_name} ({property_type}) missing rdfs:domain")
+
+            if RDFS_RANGE_RE.search(block):
+                r.ok(
+                    f"{ttl_rel}: {property_name} ({property_type}) has rdfs:range",
+                    verbose,
+                    is_verbose=True,
+                )
+            else:
+                r.fail(f"{ttl_rel}: {property_name} ({property_type}) missing rdfs:range")
+
+    return r
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Validate Kairos ontology repository structure conventions."
@@ -286,6 +362,13 @@ def main():
             print(msg)
         total_pass += result.passes
         total_fail += result.failures
+
+        if folder.parent.name == "derived-ontologies":
+            property_result = validate_property_completeness(folder, args.verbose)
+            for msg in property_result.messages:
+                print(msg)
+            total_pass += property_result.passes
+            total_fail += property_result.failures
 
     print(f"\n{'─' * 50}")
     if total_fail:


### PR DESCRIPTION
## Summary

Add missing dfs:domain and/or dfs:range declarations to ~220 properties across all 7 derived ontologies (DCSA, BSP, MMT, TIC, WCO, IMO, Sustainability).

This enforces the project convention:
> Every property must have rdfs:domain, rdfs:range, and rdfs:label.

## Changes

### Ontology fixes (34 files)
- **DCSA** — booking, equipment, container-operations, events
- **BSP** — party, commercial, compliance, documents, financial, reference-data
- **MMT** — cargo, consignment, documents, equipment, inland-transport, locations, mmt, route-network, transport-means
- **TIC** — automotive-services, events, handling-operations, locations, party, terminal-infrastructure
- **WCO** — documents, locations, party, trade-facilitation
- **IMO** — party, port-call
- **Sustainability** — carbon, energy

### CI validation (1 file)
- Added property completeness check to scripts/validate_structure.py
- CI now fails on any ObjectProperty or DatatypeProperty missing rdfs:domain/rdfs:range

## Validation
\\\
✓ All 1590 checks passed
\\\

## Notes
- No version bump needed — this is a quality/metadata fix, not a semantic change
- No new skill or design decision document required — the existing kairos-ontology-validation skill already documents this rule; the gap was purely CI enforcement