### PR TITLE
fix: normalize hash (#) in ontology IRIs, imports, and catalog

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -117,7 +117,12 @@ corresponding scenario test updates. Run `py -m pytest tests/scenarios/ -v` to v
 
 - All ontology files use Turtle (.ttl) syntax.
 - Every ontology MUST declare an `owl:Ontology` with `rdfs:label` and `owl:versionInfo`.
-- Use HTTP/HTTPS namespaces with `#` or `/` separator.
+- Use HTTP/HTTPS namespaces with `#` separator for class/property namespace prefixes.
+- **IRI convention (critical)**:
+  - `@prefix : <https://example.com/ont/domain#> .` — namespace prefix WITH `#`
+  - `<https://example.com/ont/domain> a owl:Ontology ;` — ontology IRI WITHOUT `#`
+  - `owl:imports <https://example.com/ont/other> ;` — import URIs WITHOUT `#`
+  - Catalog `name=` attributes must exactly match the `owl:imports` URI (no `#`)
 - Every `owl:Class` must have `rdfs:label` and `rdfs:comment`.
 - Every property must have `rdfs:domain`, `rdfs:range`, and `rdfs:label`.
 - Naming: PascalCase for classes, camelCase for properties.

--- a/.github/skills/kairos-ontology-modeling/SKILL.md
+++ b/.github/skills/kairos-ontology-modeling/SKILL.md
@@ -771,6 +771,9 @@ After every 3-5 classes are confirmed, pause and show:
 - **Properties**: camelCase — `customerName`, `orderDate`, `belongsToCustomer`.
 - **Namespaces**: Use HTTPS URIs matching the hub's namespace base —
   `https://<company-domain>/ont/<domain>#` (e.g., `https://contoso.com/ont/customer#`).
+- **IRI convention**: The `#` is ONLY for the namespace prefix (used by classes/properties).
+  The ontology IRI (subject of `a owl:Ontology`) and `owl:imports` URIs must NOT end with `#`.
+  Catalog `name=` entries must exactly match the `owl:imports` URIs.
 
 ## Common patterns
 
@@ -818,6 +821,11 @@ Every .ttl file MUST start with an ontology declaration:
     rdfs:comment "Description of this domain"@en ;
     owl:versionInfo "1.0.0" .
 ```
+
+**Critical**: Note the difference between the `@prefix : <...#>` (WITH `#`) and the
+ontology IRI `<...>` (WITHOUT `#`). Never use `: a owl:Ontology` shorthand — always
+use the explicit full IRI for the ontology declaration to avoid accidentally including
+`#` in the ontology IRI.
 
 ---
 

--- a/.github/skills/kairos-ontology-validation/SKILL.md
+++ b/.github/skills/kairos-ontology-validation/SKILL.md
@@ -120,7 +120,9 @@ projection output or downstream issues.
 | `rdfs:label` on ontology | Human-readable name is required |
 | `owl:versionInfo` on ontology | Semantic version string required |
 | Namespace uses `https://` | Never use `http://` — always `https://` |
-| Namespace ends with `#` or `/` | Ensures fragment or path-based local names |
+| Namespace prefix ends with `#` | `@prefix : <...#>` — required for class/property local names |
+| Ontology IRI does NOT end with `#` | 🐛 The ontology IRI (subject of `a owl:Ontology`) must be the base without `#`. Use explicit full IRI, not `: a owl:Ontology` shorthand |
+| `owl:imports` URIs do NOT end with `#` | 🐛 Import URIs must match catalog entries exactly — no trailing `#` |
 
 ### Class design
 

--- a/CATALOG-GUIDE.md
+++ b/CATALOG-GUIDE.md
@@ -33,6 +33,20 @@ scripts/
 
 ## How It Works
 
+### URI Convention (Important!)
+
+The `#` character has a specific role in ontology URIs:
+
+| Context | Example | Has `#`? |
+|---------|---------|----------|
+| Namespace prefix (`@prefix`) | `<https://www.kairosflow.ai/ont/dcsa#>` | YES — used for class/property names |
+| Ontology IRI (`a owl:Ontology`) | `<https://www.kairosflow.ai/ont/dcsa>` | NO — identifies the ontology itself |
+| Import URI (`owl:imports`) | `<https://www.kairosflow.ai/ont/dcsa/booking>` | NO — must match catalog |
+| Catalog entry (`name=`) | `"https://www.kairosflow.ai/ont/dcsa"` | NO — must match imports |
+
+**Rule**: Catalog `name` attributes must exactly match the `owl:imports` URIs used
+in ontology files. Neither should end with `#`.
+
 ### 1. Your Ontology Uses Canonical URIs
 
 [core.ttl](../ontology-hub/ontologies/core.ttl):

--- a/ontology-reference-models/accelerator-packs/financial-services/current/financial-services-accelerator.ttl
+++ b/ontology-reference-models/accelerator-packs/financial-services/current/financial-services-accelerator.ttl
@@ -5,7 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/accelerator/financial-services> a owl:Ontology ;
     dcterms:title "Kairos Financial Services Accelerator Pack" ;
     dcterms:description """Pre-composed ontology bundle for financial services companies.
     

--- a/ontology-reference-models/accelerator-packs/logistics/current/logistics-accelerator.ttl
+++ b/ontology-reference-models/accelerator-packs/logistics/current/logistics-accelerator.ttl
@@ -5,7 +5,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/accelerator/logistics> a owl:Ontology ;
     dcterms:title "Kairos Logistics Accelerator Pack" ;
     dcterms:description """Pre-composed ontology bundle for logistics companies.
     
@@ -23,11 +23,11 @@
     dcterms:created "2026-05-16"^^xsd:date ;
     dcterms:modified "2026-05-22"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa#> ,
-                <https://www.kairosflow.ai/ont/dcsa/demurrage-detention#> ,
-                <https://www.kairosflow.ai/ont/mmt#> ,
-                <https://www.kairosflow.ai/ont/bsp#> ,
-                <https://www.kairosflow.ai/ont/tic#> ,
-                <https://www.kairosflow.ai/ont/imo#> ,
-                <https://www.kairosflow.ai/ont/wco#> ,
-                <https://www.kairosflow.ai/ont/sustainability#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa> ,
+                <https://www.kairosflow.ai/ont/dcsa/demurrage-detention> ,
+                <https://www.kairosflow.ai/ont/mmt> ,
+                <https://www.kairosflow.ai/ont/bsp> ,
+                <https://www.kairosflow.ai/ont/tic> ,
+                <https://www.kairosflow.ai/ont/imo> ,
+                <https://www.kairosflow.ai/ont/wco> ,
+                <https://www.kairosflow.ai/ont/sustainability> .

--- a/ontology-reference-models/catalog-v001.xml
+++ b/ontology-reference-models/catalog-v001.xml
@@ -16,79 +16,79 @@
                 rewritePrefix="authoritative-ontologies/FIBO/current/fibo/"/>
     
     <!-- ========== DCSA (Digital Container Shipping Association) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/dcsa#" uri="derived-ontologies/DCSA/current/dcsa.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/shipment-journey#" uri="derived-ontologies/DCSA/current/shipment-journey/shipment-journey.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/booking#" uri="derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/transport-documents#" uri="derived-ontologies/DCSA/current/shipment-journey/transport-documents/transport-documents.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/equipment-journey#" uri="derived-ontologies/DCSA/current/equipment-journey/equipment-journey.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/container-operations#" uri="derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/vessel-journey#" uri="derived-ontologies/DCSA/current/vessel-journey/vessel-journey.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/schedule#" uri="derived-ontologies/DCSA/current/vessel-journey/schedule/schedule.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/track-and-trace#" uri="derived-ontologies/DCSA/current/track-and-trace/track-and-trace.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/events#" uri="derived-ontologies/DCSA/current/track-and-trace/events/events.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/shared-kernel#" uri="derived-ontologies/DCSA/current/shared-kernel/shared-kernel.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/equipment#" uri="derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/party#" uri="derived-ontologies/DCSA/current/shared-kernel/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/locations#" uri="derived-ontologies/DCSA/current/shared-kernel/locations/locations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/dcsa/demurrage-detention#" uri="derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa" uri="derived-ontologies/DCSA/current/dcsa.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/shipment-journey" uri="derived-ontologies/DCSA/current/shipment-journey/shipment-journey.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/booking" uri="derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/transport-documents" uri="derived-ontologies/DCSA/current/shipment-journey/transport-documents/transport-documents.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/equipment-journey" uri="derived-ontologies/DCSA/current/equipment-journey/equipment-journey.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/container-operations" uri="derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/vessel-journey" uri="derived-ontologies/DCSA/current/vessel-journey/vessel-journey.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/schedule" uri="derived-ontologies/DCSA/current/vessel-journey/schedule/schedule.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/track-and-trace" uri="derived-ontologies/DCSA/current/track-and-trace/track-and-trace.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/events" uri="derived-ontologies/DCSA/current/track-and-trace/events/events.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/shared-kernel" uri="derived-ontologies/DCSA/current/shared-kernel/shared-kernel.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/equipment" uri="derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/party" uri="derived-ontologies/DCSA/current/shared-kernel/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/locations" uri="derived-ontologies/DCSA/current/shared-kernel/locations/locations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/dcsa/demurrage-detention" uri="derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention.ttl"/>
     
     <!-- ========== MMT (Multi-Modal Transport) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/mmt#" uri="derived-ontologies/MMT/current/mmt.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/cargo#" uri="derived-ontologies/MMT/current/cargo/cargo.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/consignment#" uri="derived-ontologies/MMT/current/consignment/consignment.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/documents#" uri="derived-ontologies/MMT/current/documents/documents.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/equipment#" uri="derived-ontologies/MMT/current/equipment/equipment.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/events#" uri="derived-ontologies/MMT/current/events/events.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/inland-transport#" uri="derived-ontologies/MMT/current/inland-transport/inland-transport.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/locations#" uri="derived-ontologies/MMT/current/locations/locations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/party#" uri="derived-ontologies/MMT/current/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/route-network#" uri="derived-ontologies/MMT/current/route-network/route-network.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/mmt/transport-means#" uri="derived-ontologies/MMT/current/transport-means/transport-means.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt" uri="derived-ontologies/MMT/current/mmt.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/cargo" uri="derived-ontologies/MMT/current/cargo/cargo.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/consignment" uri="derived-ontologies/MMT/current/consignment/consignment.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/documents" uri="derived-ontologies/MMT/current/documents/documents.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/equipment" uri="derived-ontologies/MMT/current/equipment/equipment.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/events" uri="derived-ontologies/MMT/current/events/events.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/inland-transport" uri="derived-ontologies/MMT/current/inland-transport/inland-transport.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/locations" uri="derived-ontologies/MMT/current/locations/locations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/party" uri="derived-ontologies/MMT/current/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/route-network" uri="derived-ontologies/MMT/current/route-network/route-network.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/mmt/transport-means" uri="derived-ontologies/MMT/current/transport-means/transport-means.ttl"/>
     
     <!-- ========== BSP (Buy-Ship-Pay) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/bsp#" uri="derived-ontologies/BSP/current/bsp.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/commercial#" uri="derived-ontologies/BSP/current/commercial/commercial.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/compliance#" uri="derived-ontologies/BSP/current/compliance/compliance.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/documents#" uri="derived-ontologies/BSP/current/documents/documents.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/financial#" uri="derived-ontologies/BSP/current/financial/financial.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/cost-accounting#" uri="derived-ontologies/BSP/current/cost-accounting/cost-accounting.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/revenue-yield#" uri="derived-ontologies/BSP/current/revenue-yield/revenue-yield.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/party#" uri="derived-ontologies/BSP/current/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/bsp/reference-data#" uri="derived-ontologies/BSP/current/reference-data/reference-data.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp" uri="derived-ontologies/BSP/current/bsp.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/commercial" uri="derived-ontologies/BSP/current/commercial/commercial.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/compliance" uri="derived-ontologies/BSP/current/compliance/compliance.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/documents" uri="derived-ontologies/BSP/current/documents/documents.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/financial" uri="derived-ontologies/BSP/current/financial/financial.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/cost-accounting" uri="derived-ontologies/BSP/current/cost-accounting/cost-accounting.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/revenue-yield" uri="derived-ontologies/BSP/current/revenue-yield/revenue-yield.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/party" uri="derived-ontologies/BSP/current/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/bsp/reference-data" uri="derived-ontologies/BSP/current/reference-data/reference-data.ttl"/>
     
     <!-- ========== TIC (Terminal Industry Committee 4.0) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/tic#" uri="derived-ontologies/TIC/current/tic.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/automotive-services#" uri="derived-ontologies/TIC/current/automotive-services/automotive-services.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/events#" uri="derived-ontologies/TIC/current/events/events.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/handling-operations#" uri="derived-ontologies/TIC/current/handling-operations/handling-operations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/locations#" uri="derived-ontologies/TIC/current/locations/locations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/party#" uri="derived-ontologies/TIC/current/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/tic/terminal-infrastructure#" uri="derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic" uri="derived-ontologies/TIC/current/tic.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/automotive-services" uri="derived-ontologies/TIC/current/automotive-services/automotive-services.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/events" uri="derived-ontologies/TIC/current/events/events.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/handling-operations" uri="derived-ontologies/TIC/current/handling-operations/handling-operations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/locations" uri="derived-ontologies/TIC/current/locations/locations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/party" uri="derived-ontologies/TIC/current/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/tic/terminal-infrastructure" uri="derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl"/>
     
     <!-- ========== IMO (International Maritime Organization) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/imo#" uri="derived-ontologies/IMO/current/imo.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/imo/dangerous-goods#" uri="derived-ontologies/IMO/current/dangerous-goods/dangerous-goods.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/imo/locations#" uri="derived-ontologies/IMO/current/locations/locations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/imo/party#" uri="derived-ontologies/IMO/current/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/imo/port-call#" uri="derived-ontologies/IMO/current/port-call/port-call.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/imo/vessel-registry#" uri="derived-ontologies/IMO/current/vessel-registry/vessel-registry.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo" uri="derived-ontologies/IMO/current/imo.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo/dangerous-goods" uri="derived-ontologies/IMO/current/dangerous-goods/dangerous-goods.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo/locations" uri="derived-ontologies/IMO/current/locations/locations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo/party" uri="derived-ontologies/IMO/current/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo/port-call" uri="derived-ontologies/IMO/current/port-call/port-call.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/imo/vessel-registry" uri="derived-ontologies/IMO/current/vessel-registry/vessel-registry.ttl"/>
     
     <!-- ========== WCO (World Customs Organization) ========== -->
-    <uri name="https://www.kairosflow.ai/ont/wco#" uri="derived-ontologies/WCO/current/wco.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/wco/customs#" uri="derived-ontologies/WCO/current/customs/customs.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/wco/documents#" uri="derived-ontologies/WCO/current/documents/documents.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/wco/locations#" uri="derived-ontologies/WCO/current/locations/locations.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/wco/party#" uri="derived-ontologies/WCO/current/party/party.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/wco/trade-facilitation#" uri="derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco" uri="derived-ontologies/WCO/current/wco.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco/customs" uri="derived-ontologies/WCO/current/customs/customs.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco/documents" uri="derived-ontologies/WCO/current/documents/documents.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco/locations" uri="derived-ontologies/WCO/current/locations/locations.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco/party" uri="derived-ontologies/WCO/current/party/party.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/wco/trade-facilitation" uri="derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl"/>
     
     <!-- ========== Sustainability ========== -->
-    <uri name="https://www.kairosflow.ai/ont/sustainability#" uri="derived-ontologies/Sustainability/current/sustainability.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/sustainability/carbon#" uri="derived-ontologies/Sustainability/current/carbon/carbon.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/sustainability/energy#" uri="derived-ontologies/Sustainability/current/energy/energy.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/sustainability" uri="derived-ontologies/Sustainability/current/sustainability.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/sustainability/carbon" uri="derived-ontologies/Sustainability/current/carbon/carbon.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/sustainability/energy" uri="derived-ontologies/Sustainability/current/energy/energy.ttl"/>
     
     <!-- ========== Accelerator Packs ========== -->
-    <uri name="https://www.kairosflow.ai/ont/accelerator/logistics#" uri="accelerator-packs/logistics/current/logistics-accelerator.ttl"/>
-    <uri name="https://www.kairosflow.ai/ont/accelerator/financial-services#" uri="accelerator-packs/financial-services/current/financial-services-accelerator.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/accelerator/logistics" uri="accelerator-packs/logistics/current/logistics-accelerator.ttl"/>
+    <uri name="https://www.kairosflow.ai/ont/accelerator/financial-services" uri="accelerator-packs/financial-services/current/financial-services-accelerator.ttl"/>
     
 </catalog>
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/bsp.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/bsp.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp> a owl:Ontology ;
     dcterms:title "Kairos Buy-Ship-Pay Reference Data Model Ontology" ;
     dcterms:description """UN/CEFACT Buy-Ship-Pay Reference Data Model (BSP-RDM v1.0) ontology
     for international trade lifecycle, also published as ISO 20197-1:2024.

--- a/ontology-reference-models/derived-ontologies/BSP/current/commercial/commercial.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/commercial/commercial.ttl
@@ -8,7 +8,7 @@
 @prefix refdata: <https://www.kairosflow.ai/ont/bsp/reference-data#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/commercial> a owl:Ontology ;
     dcterms:title "Kairos BSP Commercial Domain Ontology" ;
     dcterms:description """Commercial and logistics domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/compliance/compliance.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/compliance/compliance.ttl
@@ -8,7 +8,7 @@
 @prefix refdata: <https://www.kairosflow.ai/ont/bsp/reference-data#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/compliance> a owl:Ontology ;
     dcterms:title "Kairos BSP Compliance Domain Ontology" ;
     dcterms:description """Regulatory and compliance domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/cost-accounting/cost-accounting.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/cost-accounting/cost-accounting.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/cost-accounting> a owl:Ontology ;
     dcterms:title "Kairos BSP Cost Accounting Domain Ontology" ;
     dcterms:description """Operational cost accounting domain for logistics and transport companies.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/documents/documents.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/documents/documents.ttl
@@ -7,7 +7,7 @@
 @prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/documents> a owl:Ontology ;
     dcterms:title "Kairos BSP Documents Domain Ontology" ;
     dcterms:description """Trade document domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/commercial-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/commercial-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Commercial Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/commercial/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Commercial — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Commercial domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/commercial#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/commercial> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/compliance-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/compliance-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Compliance Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/compliance/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Compliance — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Compliance domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/compliance#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/compliance> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/cost-accounting-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/cost-accounting-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Cost Accounting Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/cost-accounting/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Cost Accounting — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Cost Accounting domain ontology." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-22"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/cost-accounting#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/cost-accounting> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/documents-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/documents-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Documents Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/documents/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Documents — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Documents domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/documents#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/documents> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/financial-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/financial-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Financial Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/financial/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Financial — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Financial domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/financial#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/financial> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/party-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/party-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Party Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/party/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Party — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Party domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/party#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/party> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/reference-data-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/reference-data-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Reference Data Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/reference-data/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Reference Data — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Reference Data domain ontology. Controls DDL generation, SCD behaviour, and table structure." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-19"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/reference-data#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/reference-data> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/extensions/revenue-yield-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/extensions/revenue-yield-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — BSP Revenue & Yield Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/revenue-yield/silver-ext> a owl:Ontology ;
     dcterms:title "BSP Revenue & Yield — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the BSP Revenue & Yield domain ontology." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-22"^^xsd:date ;
     owl:versionInfo "1.2.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/bsp/revenue-yield#> ;
+    owl:imports <https://www.kairosflow.ai/ont/bsp/revenue-yield> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/BSP/current/financial/financial.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/financial/financial.ttl
@@ -7,7 +7,7 @@
 @prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/financial> a owl:Ontology ;
     dcterms:title "Kairos BSP Financial Domain Ontology" ;
     dcterms:description """Financial and payment domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/party/party.ttl
@@ -7,7 +7,7 @@
 @prefix comm: <https://www.kairosflow.ai/ont/bsp/commercial#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/party> a owl:Ontology ;
     dcterms:title "Kairos BSP Party Domain Ontology" ;
     dcterms:description """Party and organisation domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/reference-data/reference-data.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/reference-data/reference-data.ttl
@@ -8,7 +8,7 @@
 @prefix party: <https://www.kairosflow.ai/ont/bsp/party#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/reference-data> a owl:Ontology ;
     dcterms:title "Kairos BSP Reference Data Domain Ontology" ;
     dcterms:description """Reference data domain of the Buy-Ship-Pay Reference Data Model.
 

--- a/ontology-reference-models/derived-ontologies/BSP/current/revenue-yield/revenue-yield.ttl
+++ b/ontology-reference-models/derived-ontologies/BSP/current/revenue-yield/revenue-yield.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/bsp/revenue-yield> a owl:Ontology ;
     dcterms:title "Kairos BSP Revenue & Yield Domain Ontology" ;
     dcterms:description """Revenue management and yield analytics domain for logistics and transport companies.
 

--- a/ontology-reference-models/derived-ontologies/DCSA/current/dcsa.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/dcsa.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa> a owl:Ontology ;
     dcterms:title "Kairos DCSA Container Shipping Ontology" ;
     dcterms:description """Digital Container Shipping Association (DCSA) ontology for standardized
     container shipping operations, organized according to DCSA's journey-based
@@ -25,8 +25,8 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 (BKG v2.0, EBL v3.0, TNT v2.2, OVS v3.0)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/shipment-journey#> ,
-                <https://www.kairosflow.ai/ont/dcsa/equipment-journey#> ,
-                <https://www.kairosflow.ai/ont/dcsa/vessel-journey#> ,
-                <https://www.kairosflow.ai/ont/dcsa/track-and-trace#> ,
-                <https://www.kairosflow.ai/ont/dcsa/shared-kernel#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/shipment-journey> ,
+                <https://www.kairosflow.ai/ont/dcsa/equipment-journey> ,
+                <https://www.kairosflow.ai/ont/dcsa/vessel-journey> ,
+                <https://www.kairosflow.ai/ont/dcsa/track-and-trace> ,
+                <https://www.kairosflow.ai/ont/dcsa/shared-kernel> .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention-silver-ext.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention-silver-ext.ttl
@@ -10,13 +10,13 @@
 # Silver Extension — DCSA Demurrage & Detention Domain
 # =============================================================================
 
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/demurrage-detention/silver-ext> a owl:Ontology ;
     dcterms:title "DCSA Demurrage & Detention — Silver Extension" ;
     dcterms:description "Silver-layer projection annotations for the DCSA Demurrage & Detention domain ontology." ;
     dcterms:creator "Kairos Ontology Team" ;
     dcterms:created "2026-05-22"^^xsd:date ;
     owl:versionInfo "1.0.0" ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/demurrage-detention#> ;
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/demurrage-detention> ;
     kairos-ext:namingConvention "camel-to-snake" ;
     kairos-ext:includeNaturalKeyColumn "true"^^xsd:boolean ;
     kairos-ext:inlineRefThreshold "3"^^xsd:integer .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/demurrage-detention/demurrage-detention.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/demurrage-detention> a owl:Ontology ;
     dcterms:title "Kairos DCSA Demurrage & Detention Domain Ontology" ;
     dcterms:description """Demurrage and detention domain based on the DCSA D&D API standard.
 

--- a/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/container-operations/container-operations.ttl
@@ -7,7 +7,7 @@
 @prefix equip: <https://www.kairosflow.ai/ont/dcsa/equipment#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/container-operations> a owl:Ontology ;
     dcterms:title "DCSA Container Operations Domain" ;
     dcterms:description """Container lifecycle and operational concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/equipment-journey.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/equipment-journey/equipment-journey.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/equipment-journey> a owl:Ontology ;
     dcterms:title "DCSA Equipment Journey" ;
     dcterms:description """The Equipment Journey covers the lifecycle of containers from empty pickup
     through stuffing, transport, stripping, and return. This corresponds to DCSA's
@@ -20,4 +20,4 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 — 2. Equipment Journey (TNT v2.2)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/container-operations#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/container-operations> .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/equipment/equipment.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/equipment> a owl:Ontology ;
     dcterms:title "DCSA Equipment Domain" ;
     dcterms:description """Container equipment types and specifications for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/locations/locations.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/locations> a owl:Ontology ;
     dcterms:title "DCSA Locations Domain" ;
     dcterms:description """Location concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/party/party.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/party> a owl:Ontology ;
     dcterms:title "DCSA Party Domain" ;
     dcterms:description """Party role concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/shared-kernel.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shared-kernel/shared-kernel.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/shared-kernel> a owl:Ontology ;
     dcterms:title "DCSA Shared Kernel (SK)" ;
     dcterms:description """The Shared Kernel contains common entities referenced across all DCSA
     journeys. In DCSA's Information Model this includes Equipment, Party, Location,
@@ -22,6 +22,6 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 — SK (Shared Kernel)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/equipment#> ,
-                <https://www.kairosflow.ai/ont/dcsa/party#> ,
-                <https://www.kairosflow.ai/ont/dcsa/locations#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/equipment> ,
+                <https://www.kairosflow.ai/ont/dcsa/party> ,
+                <https://www.kairosflow.ai/ont/dcsa/locations> .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/booking/booking.ttl
@@ -11,7 +11,7 @@
 @prefix evt: <https://www.kairosflow.ai/ont/dcsa/events#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/booking> a owl:Ontology ;
     dcterms:title "DCSA Booking Domain" ;
     dcterms:description """Booking and shipping instruction concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/shipment-journey.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/shipment-journey.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/shipment-journey> a owl:Ontology ;
     dcterms:title "DCSA Shipment Journey" ;
     dcterms:description """The Shipment Journey covers the lifecycle of cargo from booking through
     transport document issuance. This corresponds to DCSA's Booking (BKG) and
@@ -21,5 +21,5 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 — 1. Shipment Journey (BKG v2.0, EBL v3.0)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/booking#> ,
-                <https://www.kairosflow.ai/ont/dcsa/transport-documents#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/booking> ,
+                <https://www.kairosflow.ai/ont/dcsa/transport-documents> .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/transport-documents/transport-documents.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/shipment-journey/transport-documents/transport-documents.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/transport-documents> a owl:Ontology ;
     dcterms:title "DCSA Transport Documents Domain" ;
     dcterms:description """Transport document concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/events/events.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/events/events.ttl
@@ -8,7 +8,7 @@
 @prefix equip: <https://www.kairosflow.ai/ont/dcsa/equipment#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/events> a owl:Ontology ;
     dcterms:title "DCSA Events Domain" ;
     dcterms:description """Track and trace event concepts for container shipping.
     

--- a/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/track-and-trace.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/track-and-trace/track-and-trace.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/track-and-trace> a owl:Ontology ;
     dcterms:title "DCSA Track and Trace" ;
     dcterms:description """Track and Trace covers all shipping event tracking — transport events
     (vessel movements), equipment events (container handling), and document events
@@ -20,4 +20,4 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 — Track and Trace (TNT v2.2)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/events#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/events> .

--- a/ontology-reference-models/derived-ontologies/DCSA/current/vessel-journey/vessel-journey.ttl
+++ b/ontology-reference-models/derived-ontologies/DCSA/current/vessel-journey/vessel-journey.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/dcsa/vessel-journey> a owl:Ontology ;
     dcterms:title "DCSA Vessel Journey" ;
     dcterms:description """The Vessel Journey covers vessel operations including service loops,
     sailing schedules, and port rotations. This corresponds to DCSA's Operational
@@ -20,4 +20,4 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "DCSA Information Model 2024.Q4 — 3. Vessel Journey (OVS v3.0)" ;
     rdfs:seeAlso <https://github.com/dcsaorg/DCSA-OpenAPI> ;
-    owl:imports <https://www.kairosflow.ai/ont/dcsa/schedule#> .
+    owl:imports <https://www.kairosflow.ai/ont/dcsa/schedule> .

--- a/ontology-reference-models/derived-ontologies/IMO/current/dangerous-goods/dangerous-goods.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/dangerous-goods/dangerous-goods.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo/dangerous-goods> a owl:Ontology ;
     dcterms:title "IMO Dangerous Goods Ontology" ;
     dcterms:description """Dangerous goods classification, declaration, and transport domain ontology
     aligned with the IMDG Code and the IMO Compendium.

--- a/ontology-reference-models/derived-ontologies/IMO/current/imo.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/imo.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo> a owl:Ontology ;
     dcterms:title "IMO Maritime Ontology" ;
     dcterms:description """Root ontology for the International Maritime Organization (IMO) reference data model.
 
@@ -26,8 +26,8 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "IMO Compendium data set (FAL 48, 2024), FAL Convention, SOLAS, IMDG Code, MARPOL, ISM Code" ;
     rdfs:seeAlso <https://imocompendium.imo.org/public/IMO-Compendium/Current> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry#> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/dangerous-goods#> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/port-call#> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/party#> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/locations#> .
+    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/dangerous-goods> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/port-call> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/party> ;
+    owl:imports <https://www.kairosflow.ai/ont/imo/locations> .

--- a/ontology-reference-models/derived-ontologies/IMO/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/locations/locations.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo/locations> a owl:Ontology ;
     dcterms:title "IMO Locations Ontology" ;
     dcterms:description """Maritime location and navigational area domain ontology aligned with the IMO Compendium.
 

--- a/ontology-reference-models/derived-ontologies/IMO/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/party/party.ttl
@@ -7,7 +7,7 @@
 @prefix loc: <https://www.kairosflow.ai/ont/imo/locations#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo/party> a owl:Ontology ;
     dcterms:title "IMO Party Ontology" ;
     dcterms:description """Maritime party and stakeholder domain ontology aligned with the IMO Compendium.
 
@@ -21,7 +21,7 @@
     owl:versionInfo "1.0.0" ;
     dcterms:source "IMO Compendium data set, FAL Convention, ISM Code, STCW Convention" ;
     rdfs:seeAlso <https://imocompendium.imo.org/public/IMO-Compendium/Current> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/locations#> .
+    owl:imports <https://www.kairosflow.ai/ont/imo/locations> .
 
 #################################################################
 #    Classes

--- a/ontology-reference-models/derived-ontologies/IMO/current/port-call/port-call.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/port-call/port-call.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo/port-call> a owl:Ontology ;
     dcterms:title "IMO Port Call Ontology" ;
     dcterms:description """Port call, voyage, and maritime logistics operations domain ontology aligned with
     the IMO Compendium and the FAL Convention.

--- a/ontology-reference-models/derived-ontologies/IMO/current/vessel-registry/vessel-registry.ttl
+++ b/ontology-reference-models/derived-ontologies/IMO/current/vessel-registry/vessel-registry.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/imo/vessel-registry> a owl:Ontology ;
     dcterms:title "IMO Vessel Registry Ontology" ;
     dcterms:description """Vessel registration and identification domain ontology aligned with the IMO Compendium.
 

--- a/ontology-reference-models/derived-ontologies/Sustainability/current/carbon/carbon.ttl
+++ b/ontology-reference-models/derived-ontologies/Sustainability/current/carbon/carbon.ttl
@@ -9,7 +9,7 @@
 @prefix party: <https://www.kairosflow.ai/ont/imo/party#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/sustainability/carbon> a owl:Ontology ;
     dcterms:title "Sustainability Carbon Domain" ;
     dcterms:description "Carbon emissions, greenhouse gas accounting, and environmental compliance for transport and logistics based on ISO 14083:2023 and the GLEC Framework." ;
     dcterms:creator "Kairos Ontology Team" ;
@@ -19,9 +19,9 @@
     dcterms:source "ISO 14083:2023, GLEC Framework, EU MRV Regulation, IMO DCS, EU ETS Maritime" ;
     rdfs:seeAlso <https://www.iso.org/standard/78864.html> ,
                  <https://www.smartfreightcentre.org/en/how-to-implement-glec-framework/> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry#> ,
-                <https://www.kairosflow.ai/ont/imo/port-call#> ,
-                <https://www.kairosflow.ai/ont/imo/party#> .
+    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry> ,
+                <https://www.kairosflow.ai/ont/imo/port-call> ,
+                <https://www.kairosflow.ai/ont/imo/party> .
 
 #################################################################
 #    Emission Classes

--- a/ontology-reference-models/derived-ontologies/Sustainability/current/energy/energy.ttl
+++ b/ontology-reference-models/derived-ontologies/Sustainability/current/energy/energy.ttl
@@ -8,7 +8,7 @@
 @prefix pc: <https://www.kairosflow.ai/ont/imo/port-call#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/sustainability/energy> a owl:Ontology ;
     dcterms:title "Sustainability Energy Domain" ;
     dcterms:description "Energy consumption, fuel types, and energy efficiency for transport and logistics based on EU MRV Regulation and IMO DCS." ;
     dcterms:creator "Kairos Ontology Team" ;
@@ -17,8 +17,8 @@
     owl:versionInfo "1.1.0" ;
     dcterms:source "ISO 14083:2023, GLEC Framework, EU MRV Regulation, IMO DCS, EU ETS Maritime" ;
     rdfs:seeAlso <https://www.iso.org/standard/78864.html> ;
-    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry#> ,
-                <https://www.kairosflow.ai/ont/imo/port-call#> .
+    owl:imports <https://www.kairosflow.ai/ont/imo/vessel-registry> ,
+                <https://www.kairosflow.ai/ont/imo/port-call> .
 
 #################################################################
 #    Energy Consumption and Fuel Classes

--- a/ontology-reference-models/derived-ontologies/Sustainability/current/sustainability.ttl
+++ b/ontology-reference-models/derived-ontologies/Sustainability/current/sustainability.ttl
@@ -8,7 +8,7 @@
 @prefix sust-energy: <https://www.kairosflow.ai/ont/sustainability/energy#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/sustainability> a owl:Ontology ;
     dcterms:title "Kairos Sustainability Ontology" ;
     dcterms:description """Sustainability ontology for carbon emissions, energy consumption, and environmental compliance in transport and logistics.
 
@@ -24,5 +24,5 @@
     dcterms:source "ISO 14083:2023, GLEC Framework, EU MRV Regulation, IMO DCS, EU ETS Maritime" ;
     rdfs:seeAlso <https://www.iso.org/standard/78864.html> ,
                  <https://www.smartfreightcentre.org/en/how-to-implement-glec-framework/> ;
-    owl:imports <https://www.kairosflow.ai/ont/sustainability/carbon#> ,
-                <https://www.kairosflow.ai/ont/sustainability/energy#> .
+    owl:imports <https://www.kairosflow.ai/ont/sustainability/carbon> ,
+                <https://www.kairosflow.ai/ont/sustainability/energy> .

--- a/ontology-reference-models/derived-ontologies/TIC/current/automotive-services/automotive-services.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/automotive-services/automotive-services.ttl
@@ -7,7 +7,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/automotive-services> a owl:Ontology ;
     dcterms:title "TIC 4.0 Automotive Services Ontology" ;
     dcterms:description """Automotive and vehicle processing services domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/events/events.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/events/events.ttl
@@ -11,7 +11,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/events> a owl:Ontology ;
     dcterms:title "TIC 4.0 Events Ontology" ;
     dcterms:description """Operational events and milestones domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/handling-operations/handling-operations.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/handling-operations/handling-operations.ttl
@@ -8,7 +8,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/handling-operations> a owl:Ontology ;
     dcterms:title "TIC 4.0 Handling Operations Ontology" ;
     dcterms:description """Cargo handling operations domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/locations/locations.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/locations> a owl:Ontology ;
     dcterms:title "TIC 4.0 Locations Ontology" ;
     dcterms:description """Terminal locations and positioning domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/party/party.ttl
@@ -7,7 +7,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/party> a owl:Ontology ;
     dcterms:title "TIC 4.0 Party Ontology" ;
     dcterms:description """Party roles domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/terminal-infrastructure/terminal-infrastructure.ttl
@@ -7,7 +7,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic/terminal-infrastructure> a owl:Ontology ;
     dcterms:title "TIC 4.0 Terminal Infrastructure Ontology" ;
     dcterms:description """Terminal infrastructure and equipment domain of the TIC 4.0 ontology.
 

--- a/ontology-reference-models/derived-ontologies/TIC/current/tic.ttl
+++ b/ontology-reference-models/derived-ontologies/TIC/current/tic.ttl
@@ -12,7 +12,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/tic> a owl:Ontology ;
     dcterms:title "Kairos TIC 4.0 Terminal Industry Ontology" ;
     dcterms:description """Terminal Industry Committee (TIC) 4.0 ontology for standardized terminal and port operations.
 
@@ -31,9 +31,9 @@
     owl:versionInfo "1.1.0" ;
     dcterms:source "TIC4.0 Release 2025.017 / BSI PAS 4000:2026" ;
     rdfs:seeAlso <https://tic40.org/standards/> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/terminal-infrastructure#> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/handling-operations#> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/automotive-services#> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/party#> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/locations#> ;
-    owl:imports <https://www.kairosflow.ai/ont/tic/events#> .
+    owl:imports <https://www.kairosflow.ai/ont/tic/terminal-infrastructure> ;
+    owl:imports <https://www.kairosflow.ai/ont/tic/handling-operations> ;
+    owl:imports <https://www.kairosflow.ai/ont/tic/automotive-services> ;
+    owl:imports <https://www.kairosflow.ai/ont/tic/party> ;
+    owl:imports <https://www.kairosflow.ai/ont/tic/locations> ;
+    owl:imports <https://www.kairosflow.ai/ont/tic/events> .

--- a/ontology-reference-models/derived-ontologies/WCO/current/customs/customs.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/customs/customs.ttl
@@ -6,7 +6,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco/customs> a owl:Ontology ;
     dcterms:title "WCO Customs Domain" ;
     dcterms:description "Customs declarations, duty calculations, tariff classifications, and filing procedures based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/documents/documents.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/documents/documents.ttl
@@ -7,7 +7,7 @@
 @prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco/documents> a owl:Ontology ;
     dcterms:title "WCO Documents Domain" ;
     dcterms:description "Customs and trade documents including declarations, permits, transit documents, and international trade carnets based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/locations/locations.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/locations/locations.ttl
@@ -7,7 +7,7 @@
 @prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco/locations> a owl:Ontology ;
     dcterms:title "WCO Locations Domain" ;
     dcterms:description "Customs locations, border crossings, bonded facilities, and controlled areas based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/party/party.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/party/party.ttl
@@ -7,7 +7,7 @@
 @prefix wco-customs: <https://www.kairosflow.ai/ont/wco/customs#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco/party> a owl:Ontology ;
     dcterms:title "WCO Party Domain" ;
     dcterms:description "Party roles in customs processes including declarants, authorities, brokers, and traders based on the WCO Data Model 3.10.0." ;
     dcterms:creator "Kairos Ontology Team" ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/trade-facilitation/trade-facilitation.ttl
@@ -8,7 +8,7 @@
 @prefix wco-party: <https://www.kairosflow.ai/ont/wco/party#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco/trade-facilitation> a owl:Ontology ;
     dcterms:title "WCO Trade Facilitation Domain" ;
     dcterms:description "Trade facilitation certificates, permits, and trusted trader programmes based on the WCO Data Model 3.10.0 and eFTI Regulation." ;
     dcterms:creator "Kairos Ontology Team" ;

--- a/ontology-reference-models/derived-ontologies/WCO/current/wco.ttl
+++ b/ontology-reference-models/derived-ontologies/WCO/current/wco.ttl
@@ -11,7 +11,7 @@
 @prefix wco-doc: <https://www.kairosflow.ai/ont/wco/documents#> .
 
 # Ontology Metadata
-: a owl:Ontology ;
+<https://www.kairosflow.ai/ont/wco> a owl:Ontology ;
     dcterms:title "Kairos WCO Customs Ontology" ;
     dcterms:description """World Customs Organization (WCO) ontology for international customs procedures and trade facilitation.
 
@@ -29,8 +29,8 @@
     owl:versionInfo "1.1.0" ;
     dcterms:source "WCO Data Model 3.10.0, eFTI Regulation (EU) 2020/1056" ;
     rdfs:seeAlso <https://www.wcoomd.org/datamodel> ;
-    owl:imports <https://www.kairosflow.ai/ont/wco/customs#> ,
-                <https://www.kairosflow.ai/ont/wco/trade-facilitation#> ,
-                <https://www.kairosflow.ai/ont/wco/party#> ,
-                <https://www.kairosflow.ai/ont/wco/locations#> ,
-                <https://www.kairosflow.ai/ont/wco/documents#> .
+    owl:imports <https://www.kairosflow.ai/ont/wco/customs> ,
+                <https://www.kairosflow.ai/ont/wco/trade-facilitation> ,
+                <https://www.kairosflow.ai/ont/wco/party> ,
+                <https://www.kairosflow.ai/ont/wco/locations> ,
+                <https://www.kairosflow.ai/ont/wco/documents> .

--- a/scripts/catalog_utils.py
+++ b/scripts/catalog_utils.py
@@ -49,12 +49,11 @@ class CatalogResolver:
                 catalog_dir = self.catalog_path.parent
                 local_path = (catalog_dir / uri_path).resolve()
                 
-                # Normalize URI (ensure trailing slash consistency)
-                normalized_uri = uri_name.rstrip('/') + '/'
-                self.mappings[normalized_uri] = local_path
-                
-                # Also add without trailing slash for flexibility
-                self.mappings[normalized_uri.rstrip('/')] = local_path
+                # Normalize URI (strip trailing # and / for consistent lookup)
+                base_uri = uri_name.rstrip('#').rstrip('/')
+                self.mappings[base_uri] = local_path
+                self.mappings[base_uri + '/'] = local_path
+                self.mappings[base_uri + '#'] = local_path
     
     def resolve(self, uri: str) -> Optional[Path]:
         """
@@ -70,14 +69,16 @@ class CatalogResolver:
         if uri in self.mappings:
             return self.mappings[uri]
         
-        # Try with/without trailing slash
-        uri_with_slash = uri.rstrip('/') + '/'
-        if uri_with_slash in self.mappings:
-            return self.mappings[uri_with_slash]
+        # Normalize: strip trailing # and / then try variants
+        base_uri = uri.rstrip('#').rstrip('/')
+        if base_uri in self.mappings:
+            return self.mappings[base_uri]
         
-        uri_without_slash = uri.rstrip('/')
-        if uri_without_slash in self.mappings:
-            return self.mappings[uri_without_slash]
+        if base_uri + '/' in self.mappings:
+            return self.mappings[base_uri + '/']
+        
+        if base_uri + '#' in self.mappings:
+            return self.mappings[base_uri + '#']
         
         return None
     


### PR DESCRIPTION
## Changes

- Ontology IRIs now use explicit full IRI without \#\ (not \: a owl:Ontology\ shorthand)
- All 54 \owl:imports\ URIs stripped of trailing \#\
- All 59 catalog \
ame=\ attributes stripped of trailing \#\
- \CatalogResolver\ updated to normalize \#\ (like existing \/\ normalization)
- Skills & instructions updated with explicit IRI convention documentation

## Convention enforced

| Context | Has \#\? |
|---------|----------|
| \@prefix :\ namespace | YES |
| \ owl:Ontology\ IRI | NO |
| \owl:imports\ URI | NO |
| Catalog \
ame=\ | NO |

## Validation

- \py scripts/validate_structure.py\ — 1801 checks passed ✅
- \py scripts/test_catalog.py\ — 177 mappings valid ✅