### PR TITLE
docs: refresh logistics intro with latest versions

### DIFF
--- a/ontology-reference-models/accelerator-packs/logistics/.intro/01-purpose-of-logistics-blueprint.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/01-purpose-of-logistics-blueprint.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 The logistics blueprint defines a practical way to build a client ontology hub for freight forwarding and logistics operations using reusable reference ontologies plus client-specific extensions.
 

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/01-purpose-of-logistics-blueprint.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/01-purpose-of-logistics-blueprint.md
@@ -1,0 +1,26 @@
+# Purpose of the Logistics Ontology Blueprint
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+The logistics blueprint defines a practical way to build a client ontology hub for freight forwarding and logistics operations using reusable reference ontologies plus client-specific extensions.
+
+## Why this blueprint exists
+
+1. Provide a domain-first structure so teams model by business ownership, not by source systems.
+2. Reuse proven reference models through selective `owl:imports` instead of reinventing core logistics concepts.
+3. Keep extension work explicit by separating reference semantics from client-specific requirements.
+4. Support downstream silver/gold projections with consistent ontology boundaries.
+
+## What this gives to each audience
+
+| Audience | Primary value |
+|---|---|
+| Data architect | Consistent domain decomposition, import strategy, and model boundaries |
+| Business analyst (logistics) | Shared domain language and clear scope per capability area |
+| Domain architect | Controlled extension points and overlap resolution rules across standards |
+
+## Scope in one sentence
+
+A curated logistics ontology operating model that combines domain ownership, selected industry standards, and integration patterns to produce a best-fit semantic foundation for freight forwarders.

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/02-data-domains-in-scope.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/02-data-domains-in-scope.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 The blueprint groups domain ontologies by business ownership question (L1 group) and concrete domain modules (L2).
 

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/02-data-domains-in-scope.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/02-data-domains-in-scope.md
@@ -1,0 +1,51 @@
+# Data Domains in Scope (Logistics Blueprint)
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+The blueprint groups domain ontologies by business ownership question (L1 group) and concrete domain modules (L2).
+
+## Group and domain overview
+
+| L1 Group | Ownership question | L2 domains in scope |
+|---|---|---|
+| Party & Commercial | Who are we doing business with, under what terms, at what price? | Party, Commercial, Booking, Financial |
+| Transport & Cargo | What is being moved, by which route and asset? | Consignment, Cargo, Equipment, Route-Schedule, Intermodal |
+| Maritime & Terminal | What happens on vessels, at berths, gates, and yards? | Vessel-Maritime, Terminal-Operations, RoRo, Automotive |
+| Compliance & Sustainability | What must be reported or restricted? | Dangerous-Goods, Customs, Compliance, Sustainability |
+| Visibility & Events | What happened, where, when, to what? | Events, Claims, Documents, Reference-Data |
+| Master Data Management | What is the single golden-record truth? | MDM |
+
+## Quick domain coverage
+
+| Domain | Quick coverage summary |
+|---|---|
+| Party | Legal entities, organisations, roles, contacts |
+| Commercial | Contracts, trade terms, service commitments |
+| Booking | Quotes, booking lifecycle, customer instructions |
+| Financial | Charges, surcharges, invoicing, settlement, revenue and cost analytics |
+| Consignment | Shipments, transport legs, multimodal movement |
+| Cargo | Goods, packaging, dimensions, weight, handling attributes |
+| Equipment | Containers, trailers, reefers, chassis, equipment status |
+| Route-Schedule | Service loops, schedules, cut-offs, transit times |
+| Intermodal | Inland transport execution (rail, barge, road legs) |
+| Vessel-Maritime | Vessel registry, voyages, port call lifecycle |
+| Terminal-Operations | Berths, gates, yards, handling moves, stevedoring |
+| RoRo | RoRo-specific rolling cargo and lane-metre context |
+| Automotive | Vehicle logistics services (PDI, wash, repair, release) |
+| Dangerous-Goods | DG classification, restrictions, IMDG-aligned semantics |
+| Customs | Customs declarations, border filings, regulatory statuses |
+| Compliance | Governance, policy, legal and regulatory obligations |
+| Sustainability | Emissions, energy, ESG indicators and reporting |
+| Events | Cross-domain operational event normalization |
+| Claims | Damage, incidents, exceptions and claim lifecycle |
+| Documents | Transport/commercial documents and evidence links |
+| Reference-Data | Shared codes, identifiers, locations, UoM, currencies |
+| MDM | Golden records, crosswalks, match/merge, survivorship |
+
+## Notes for implementation
+
+- Not every client activates every domain in phase 1.
+- Specialist domains (for example RoRo, Automotive, Intermodal) are activated based on operational profile.
+- MDM is intentionally cross-cutting and decoupled from domain imports.

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/03-industry-model-selection-for-freight-forwarders.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/03-industry-model-selection-for-freight-forwarders.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 The logistics blueprint combines multiple industry models because no single model fully covers the freight forwarder operating model end-to-end.
 
@@ -16,16 +16,16 @@ Nothing is constrained:
 
 ## Selected model stack
 
-| Model | Main contribution in the blueprint |
-|---|---|
-| DCSA | Container shipping lifecycle, booking, transport documents, events, schedule |
-| MMT (UN/CEFACT) | Multimodal transport semantics for consignment, cargo, equipment, inland legs |
-| BSP (ISO 20197-1) | Commercial and financial backbone (party, contract, invoice, settlement) |
-| TIC 4.0 | Terminal and automotive operational model |
-| IMO | Maritime authority model (vessel registry, port call, dangerous goods) |
-| WCO | Customs and trade facilitation model |
-| Sustainability | Emissions, energy, ESG metrics |
-| Supply Chain Integration | Cross-standard bridge properties across domains |
+| Model | Current version | Main contribution in the blueprint |
+|---|---|---|
+| DCSA | 1.1.0 | Container shipping lifecycle, booking, transport documents, events, schedule |
+| MMT (UN/CEFACT) | 1.0.0 | Multimodal transport semantics for consignment, cargo, equipment, inland legs |
+| BSP (ISO 20197-1) | 1.3.0 | Commercial and financial backbone (party, contract, invoice, settlement) |
+| TIC 4.0 | 1.2.0 | Terminal and automotive operational model |
+| IMO | 1.1.0 | Maritime authority model (vessel registry, port call, dangerous goods) |
+| WCO | 1.2.0 | Customs and trade facilitation model |
+| Sustainability | 1.1.0 | Emissions, energy, ESG metrics |
+| Supply Chain Integration | 1.1.0 | Cross-standard bridge properties across domains |
 
 ## Why this is a best fit for freight forwarders
 

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/03-industry-model-selection-for-freight-forwarders.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/03-industry-model-selection-for-freight-forwarders.md
@@ -1,0 +1,52 @@
+# Industry Model Selection for Freight Forwarders
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+The logistics blueprint combines multiple industry models because no single model fully covers the freight forwarder operating model end-to-end.
+
+## Important positioning
+
+This blueprint is an **opinionated combination** of industry models we bring together for a pragmatic freight-forwarder fit.
+
+Nothing is constrained:
+- If more detailed domain coverage is needed, additional domains from open industry models can be added.
+- If a capability is not (well) covered by industry models, customer-specific domains can be added.
+
+## Selected model stack
+
+| Model | Main contribution in the blueprint |
+|---|---|
+| DCSA | Container shipping lifecycle, booking, transport documents, events, schedule |
+| MMT (UN/CEFACT) | Multimodal transport semantics for consignment, cargo, equipment, inland legs |
+| BSP (ISO 20197-1) | Commercial and financial backbone (party, contract, invoice, settlement) |
+| TIC 4.0 | Terminal and automotive operational model |
+| IMO | Maritime authority model (vessel registry, port call, dangerous goods) |
+| WCO | Customs and trade facilitation model |
+| Sustainability | Emissions, energy, ESG metrics |
+| Supply Chain Integration | Cross-standard bridge properties across domains |
+
+## Why this is a best fit for freight forwarders
+
+1. It covers the full process chain from quote/booking to execution, events, compliance, and settlement.
+2. It respects authority by using the strongest source per domain (for example IMO for maritime and WCO for customs).
+3. It supports multimodal reality (ocean, inland, terminal, intermodal, automotive).
+4. It preserves integration flexibility through explicit cross-domain bridge properties.
+
+## Design strategy used to bring models together
+
+- **Domain ownership first:** each concept is owned by one domain and one canonical source.
+- **Overlap resolution:** ambiguous concepts are explicitly resolved in `data-domains.yaml`.
+- **Selective imports:** domain files import only required modules, not entire bundles.
+- **Cross-standard linking:** bridge relationships are centralized in the Supply Chain integration layer.
+
+## Per-model detail sheets
+
+See `industry-models/` for one-page model charts with:
+- what it is
+- main focus
+- governance/ownership
+- official references
+- ontology links (OWL URI and/or model documentation)
+- adoption context

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/README.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/README.md
@@ -1,0 +1,27 @@
+# Logistics Blueprint Reference Documentation
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+This folder contains a business-and-architecture oriented documentation set for the logistics client hub blueprint.
+
+**Target audience**
+- Data architects
+- Logistics business analysts
+- Domain architects
+
+## Documents
+
+- [01-purpose-of-logistics-blueprint.md](01-purpose-of-logistics-blueprint.md)
+- [02-data-domains-in-scope.md](02-data-domains-in-scope.md)
+- [03-industry-model-selection-for-freight-forwarders.md](03-industry-model-selection-for-freight-forwarders.md)
+- [industry-models/](industry-models/)
+
+## Source basis
+
+This documentation is based on:
+- `accelerator-packs/logistics/client-hub-blueprint/BLUEPRINT.md`
+- `accelerator-packs/logistics/client-hub-blueprint/data-domains.yaml`
+- `accelerator-packs/logistics/README.md`
+- `derived-ontologies/*/README.md`

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/README.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/README.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 This folder contains a business-and-architecture oriented documentation set for the logistics client hub blueprint.
 
@@ -10,6 +10,20 @@ This folder contains a business-and-architecture oriented documentation set for 
 - Data architects
 - Logistics business analysts
 - Domain architects
+
+## Version snapshot (current)
+
+| Component | Version |
+|---|---|
+| Logistics accelerator pack | 1.3.0 |
+| BSP | 1.3.0 |
+| DCSA | 1.1.0 |
+| IMO | 1.1.0 |
+| MMT | 1.0.0 |
+| SupplyChain | 1.1.0 |
+| Sustainability | 1.1.0 |
+| TIC | 1.2.0 |
+| WCO | 1.2.0 |
 
 ## Documents
 

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/README.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/README.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 Per-model overview sheets used in the logistics blueprint documentation:
 
@@ -14,3 +14,16 @@ Per-model overview sheets used in the logistics blueprint documentation:
 - [wco.md](wco.md)
 - [sustainability.md](sustainability.md)
 - [supply-chain-integration.md](supply-chain-integration.md)
+
+## Reference versions used by this blueprint
+
+| Model | Version |
+|---|---|
+| BSP | 1.3.0 |
+| DCSA | 1.1.0 |
+| IMO | 1.1.0 |
+| MMT | 1.0.0 |
+| SupplyChain | 1.1.0 |
+| Sustainability | 1.1.0 |
+| TIC | 1.2.0 |
+| WCO | 1.2.0 |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/README.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/README.md
@@ -1,0 +1,16 @@
+# Industry Model Sheets
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+Per-model overview sheets used in the logistics blueprint documentation:
+
+- [dcsa.md](dcsa.md)
+- [mmt-un-cefact.md](mmt-un-cefact.md)
+- [bsp-iso-20197.md](bsp-iso-20197.md)
+- [tic-4-0.md](tic-4-0.md)
+- [imo.md](imo.md)
+- [wco.md](wco.md)
+- [sustainability.md](sustainability.md)
+- [supply-chain-integration.md](supply-chain-integration.md)

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/bsp-iso-20197.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/bsp-iso-20197.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/bsp-iso-20197.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/bsp-iso-20197.md
@@ -1,0 +1,33 @@
+# BSP (ISO 20197-1) Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | The Buy-Ship-Pay reference data model (ISO 20197-1), represented as modular OWL domain ontologies. |
+| Main focus | Party roles, commercial agreements, invoicing/charges, compliance, documents, and reference data. |
+| Why selected in this blueprint | Supplies the commercial and financial backbone that complements operational transport standards. |
+| Who is behind it | ISO standardization stream with UN/CEFACT-aligned concepts; implemented in Kairos domain modules. |
+| Official site / references | https://www.iso.org |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/bsp#` |
+| Adoption context | Strong fit for organizations that need standardized commercial and settlement semantics across transport chains. |
+| Kairos modules used | `bsp/party`, `bsp/commercial`, `bsp/financial`, `bsp/documents`, `bsp/compliance`, `bsp/reference-data`, `bsp/cost-accounting`, `bsp/revenue-yield`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/BSP/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `TradeParty` | Generic business party participating in buy-ship-pay interactions. | `partyIdentifier`, `partyRole`, `hasAddress` |
+| `SalesContract` | Commercial agreement defining terms, obligations, and conditions. | `contractNumber`, `validFrom`, `tradeTerm` |
+| `Invoice` | Financial claim document for charges and settlement. | `invoiceNumber`, `invoiceDate`, `totalAmount` |
+| `Charge` | Monetary component applied to transport/commercial transactions. | `chargeType`, `chargeAmount`, `currencyCode` |
+| `TariffSchedule` | Structured pricing/rate framework used in contracting and billing. | `rateCode`, `effectiveDate`, `appliesToService` |
+| `Payment` | Settlement action that clears invoices and outstanding balances. | `paymentReference`, `paymentDate`, `paidAmount` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/dcsa.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/dcsa.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/dcsa.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/dcsa.md
@@ -1,0 +1,33 @@
+# DCSA Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A shipping information model from the Digital Container Shipping Association, represented here as modular OWL ontologies. |
+| Main focus | Shipment journey, booking, transport documents, equipment journey, vessel journey, and track-and-trace events. |
+| Why selected in this blueprint | Provides authoritative container-shipping process semantics and event models for ocean-forwarding scenarios. |
+| Who is behind it | Digital Container Shipping Association (DCSA). |
+| Official site / references | https://dcsa.org |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/dcsa#` |
+| Adoption context | Commonly used as a shared API and information model baseline across container-shipping integrations. |
+| Kairos modules used | `dcsa/booking`, `dcsa/shipment-journey`, `dcsa/transport-documents`, `dcsa/schedule`, `dcsa/events`, `dcsa/track-and-trace`, `dcsa/equipment`, `dcsa/vessel-journey`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/DCSA/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `Booking` | Customer request and confirmation container for transport planning. | `hasBookingParty`, `bookingStatus`, `requestedEquipmentType` |
+| `Shipment` | End-to-end shipping movement unit tracked through the journey. | `origin`, `destination`, `shipmentStatus` |
+| `TransportDocument` | Official transport documentation (for example bill of lading variants). | `documentNumber`, `issueDate`, `documentStatus` |
+| `Container` | Reusable equipment unit used to carry shipment cargo. | `equipmentReference`, `isoEquipmentCode`, `containerOperationalStatus` |
+| `ServiceLoop` | Planned vessel service pattern used for routing and scheduling. | `serviceCode`, `hasPortCallSequence`, `plannedTransitTime` |
+| `Event` | Normalized milestone/event object for track-and-trace visibility. | `eventType`, `eventDateTime`, `eventLocation` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/imo.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/imo.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/imo.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/imo.md
@@ -1,0 +1,33 @@
+# IMO Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A maritime ontology aligned with IMO Compendium, FAL Convention, and IMDG references. |
+| Main focus | Vessel registry, dangerous goods, port call lifecycle, maritime parties, and maritime locations. |
+| Why selected in this blueprint | Provides authoritative maritime and dangerous-goods semantics for vessel and port-call domains. |
+| Who is behind it | International Maritime Organization (IMO). |
+| Official site / references | https://www.imo.org |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/imo#` |
+| Adoption context | Core reference body for global maritime safety, facilitation, and dangerous-goods standards. |
+| Kairos modules used | `imo/vessel-registry`, `imo/dangerous-goods`, `imo/port-call`, `imo/party`, `imo/locations`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/IMO/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `Vessel` | Maritime transport asset identified by IMO-aligned registry semantics. | `imoNumber`, `flagState`, `vesselType` |
+| `PortCall` | Arrival/departure lifecycle event of a vessel at a port. | `arrivalDateTime`, `departureDateTime`, `portCallStatus` |
+| `BerthStay` | Time-bounded vessel stay at a specific berth location. | `berthStartTime`, `berthEndTime`, `berthsAt` |
+| `DangerousGoodsItem` | Hazardous cargo unit classified under IMDG concepts. | `unNumber`, `hazardClass`, `packingGroup` |
+| `ClassificationSociety` | Maritime authority/organization responsible for vessel class oversight. | `societyCode`, `classificationStatus`, `issuesCertificate` |
+| `Port` | Maritime location entity used in voyages, calls, and navigation context. | `unlocode`, `portName`, `countryCode` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/mmt-un-cefact.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/mmt-un-cefact.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/mmt-un-cefact.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/mmt-un-cefact.md
@@ -1,0 +1,33 @@
+# MMT (UN/CEFACT) Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | The UN/CEFACT Multi-Modal Transport reference model, modularized into OWL domains. |
+| Main focus | Consignment, cargo, equipment, route-network, inland transport, party, locations, documents, and transport events. |
+| Why selected in this blueprint | Provides multimodal transport semantics beyond deep-sea container flow, including inland and intermodal coverage needed by freight forwarders. |
+| Who is behind it | UN/CEFACT (United Nations Centre for Trade Facilitation and Electronic Business). |
+| Official site / references | https://unece.org/trade/uncefact |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/mmt#` |
+| Adoption context | Widely referenced in trade-facilitation and logistics data harmonization programs across borders and transport modes. |
+| Kairos modules used | `mmt/consignment`, `mmt/cargo`, `mmt/equipment`, `mmt/route-network`, `mmt/inland-transport`, `mmt/party`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/MMT/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `Consignment` | Core multimodal shipment object across transport legs and parties. | `consignmentIdentifier`, `hasConsignmentItem`, `consignmentStatus` |
+| `CargoItem` | Physical cargo unit with commodity and handling semantics. | `grossWeight`, `hasCommodity`, `hasHandlingRequirement` |
+| `TransportEquipment` | Equipment used in movement, such as container/trailer types. | `equipmentIdentifier`, `equipmentTypeCode`, `equipmentStatus` |
+| `TransportLeg` | Segment of a route executed by a specific mode/carrier context. | `modeCode`, `departureLocation`, `arrivalLocation` |
+| `Route` | Network path abstraction used for planning and execution references. | `routeCode`, `hasLeg`, `plannedTransitTime` |
+| `InlandLeg` | Inland rail/barge/road movement segment in intermodal chains. | `inlandMode`, `inlandCarrier`, `handoverPoint` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/supply-chain-integration.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/supply-chain-integration.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/supply-chain-integration.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/supply-chain-integration.md
@@ -1,0 +1,34 @@
+# Supply Chain Integration Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A Kairos integration ontology that defines bridge properties between classes from different standards. |
+| Main focus | Cross-standard semantic links (for example booking-to-consignment, event-to-vessel, consignment-to-customs). |
+| Why selected in this blueprint | Prevents siloed standards by making interoperability explicit where no single standard defines the bridge. |
+| Who is behind it | Kairos Ontology Team. |
+| Official site / references | Internal ontology module (`https://www.kairosflow.ai/ont/supply-chain#`) and blueprint registry documentation. |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/supply-chain#` |
+| Adoption context | Used as an integration layer when combining DCSA, MMT, BSP, IMO, TIC, and WCO in one client ontology hub. |
+| Kairos modules used | `supply-chain` cross-domain properties referenced in `data-domains.yaml` under `cross_domain_relationships`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/SupplyChain/README.md`
+- `ontology-reference-models/accelerator-packs/logistics/client-hub-blueprint/data-domains.yaml`
+
+## Annex A — Main relationship anchors (high-level overview)
+
+> This is a high-level overview of representative cross-standard anchors (not a full bridge registry).
+
+| Anchor (cross-standard) | High-level explanation | Example bridge properties |
+|---|---|---|
+| `DCSA Booking` → `MMT Consignment` | Connects commercial booking intent to multimodal execution object. | `sc:bookedConsignment` |
+| `MMT Consignment` ↔ `BSP Invoice` | Links execution flow to financial settlement artifacts. | `sc:invoicedVia`, `sc:chargesForConsignment` |
+| `IMO PortCall` → `TIC Terminal` | Bridges maritime call lifecycle to terminal operational location. | `sc:callsAtTerminal`, `sc:berthsAt` |
+| `MMT CargoItem` → `IMO DangerousGoodsItem` | Connects cargo semantics to dangerous-goods classification. | `sc:classifiedAsDangerousGoods` |
+| `MMT Consignment` → `WCO CustomsDeclaration` | Represents customs obligation on cross-border consignments. | `sc:requiresCustomsDeclaration` |
+| `DCSA Event` → `MMT/IMO entities` | Ties shipping events to transport execution and vessel context. | `sc:eventRelatesToConsignment`, `sc:eventRelatesToVessel` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/sustainability.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/sustainability.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/sustainability.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/sustainability.md
@@ -1,0 +1,33 @@
+# Sustainability Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A sustainability ontology for transport and logistics, aligned with ISO 14083, GLEC, EU MRV/ETS, and IMO efficiency schemes. |
+| Main focus | Carbon emissions, emission factors, energy consumption, fuel and ESG-related indicators. |
+| Why selected in this blueprint | Enables consistent emissions and energy semantics directly tied to logistics operations and reporting. |
+| Who is behind it | Standards-led alignment (ISO/GLEC/EU/IMO) with Kairos implementation. |
+| Official site / references | https://www.iso.org/standard/78864.html |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/sustainability#` |
+| Adoption context | Increasingly required for compliance reporting and sustainability KPI governance in logistics networks. |
+| Kairos modules used | `sustainability/carbon`, `sustainability/energy`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/Sustainability/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `CarbonEmission` | Measured or calculated emission result for logistics activity. | `co2eAmount`, `calculationMethod`, `reportingPeriod` |
+| `EmissionFactor` | Conversion factor used to compute emissions from activity data. | `factorValue`, `factorUnit`, `factorSource` |
+| `CO2Intensity` | Emission intensity indicator normalized by transport work. | `intensityValue`, `intensityUnit`, `transportWorkBasis` |
+| `EnergyConsumption` | Measured energy/fuel use in operations and transport legs. | `energyAmount`, `energyUnit`, `consumptionPeriod` |
+| `FuelType` | Fuel categorization supporting energy and emission accounting. | `fuelCode`, `fuelCategory`, `defaultEmissionFactor` |
+| `EmissionReport` | Reporting object for compliance and ESG disclosure outputs. | `reportIdentifier`, `reportingScope`, `submissionDate` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/tic-4-0.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/tic-4-0.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/tic-4-0.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/tic-4-0.md
@@ -1,0 +1,33 @@
+# TIC 4.0 Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A terminal-industry ontology aligned with TIC 4.0 and BSI PAS 4000, modularized for infrastructure, handling, automotive, party, locations, and events. |
+| Main focus | Terminal operations and physical assets: berths, yards, gates, handling moves, and automotive services. |
+| Why selected in this blueprint | Adds terminal-depth semantics that are not fully covered by shipping and multimodal transport models. |
+| Who is behind it | TIC4.0 ecosystem and BSI standardization (PAS 4000 context). |
+| Official site / references | https://tic40.org/standards/ |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/tic#` |
+| Adoption context | Positioned for ports and terminal operators standardizing operational and event semantics. |
+| Kairos modules used | `tic/terminal-infrastructure`, `tic/handling-operations`, `tic/locations`, `tic/events`, `tic/automotive-services`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/TIC/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `Terminal` | Port/terminal operational facility as core site entity. | `terminalCode`, `hasBerth`, `terminalOperator` |
+| `Berth` | Vessel mooring position where loading/discharge activities occur. | `berthIdentifier`, `berthLength`, `maxDraft` |
+| `YardArea` | Storage and staging area for equipment/cargo handling flows. | `yardBlockCode`, `capacityTEU`, `temperatureControlled` |
+| `CargoVisit` | Terminal visit lifecycle context for cargo/equipment movements. | `visitReference`, `arrivalTime`, `departureTime` |
+| `Move` | Operational handling action (load/discharge/lift/horizontal). | `moveType`, `plannedTime`, `executedTime` |
+| `TerminalEvent` | Event object for gate, yard, vessel, and service milestones. | `eventType`, `eventTimestamp`, `eventLocation` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/wco.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/wco.md
@@ -1,0 +1,33 @@
+# WCO Model Sheet
+
+> **Document Control**  
+> **Framework:** Kairos Ontology Toolkit  
+> **Document date:** 2026-06-11
+
+| Item | Details |
+|---|---|
+| What is it? | A customs and trade-facilitation ontology aligned with the WCO Data Model and related customs frameworks. |
+| Main focus | Customs declarations, tariff and duty semantics, trade facilitation, trusted trader and border filing concepts. |
+| Why selected in this blueprint | Covers customs/regulatory requirements that are essential in freight forwarding across borders. |
+| Who is behind it | World Customs Organization (WCO). |
+| Official site / references | https://www.wcoomd.org/datamodel |
+| Ontology / OWL reference | `https://www.kairosflow.ai/ont/wco#` |
+| Adoption context | Common baseline for customs digitalization and cross-border declaration interoperability. |
+| Kairos modules used | `wco/customs`, `wco/trade-facilitation`. |
+
+## Internal reference
+
+- `ontology-reference-models/derived-ontologies/WCO/README.md`
+
+## Annex A — Main classes (high-level overview)
+
+> This is a high-level overview of representative classes (not a full class catalog).
+
+| Class | High-level explanation | Example properties |
+|---|---|---|
+| `CustomsDeclaration` | Formal declaration object submitted to customs authorities. | `declarationNumber`, `declarationStatus`, `lodgementDate` |
+| `ImportDeclaration` | Declaration subtype for inbound goods clearance processing. | `countryOfOrigin`, `importProcedureCode`, `releaseDate` |
+| `ExportDeclaration` | Declaration subtype for outbound goods compliance processing. | `destinationCountry`, `exportProcedureCode`, `exitOffice` |
+| `TariffClassification` | Commodity classification used for duty/tax determination. | `hsCode`, `commodityDescription`, `dutyRate` |
+| `DutyCalculation` | Computation entity for payable customs amounts. | `customsValue`, `dutyAmount`, `taxAmount` |
+| `AEOCertification` | Trusted trader certification concept used in facilitation programs. | `aeoStatus`, `certificateNumber`, `validUntil` |

--- a/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/wco.md
+++ b/ontology-reference-models/accelerator-packs/logistics/.intro/industry-models/wco.md
@@ -2,7 +2,7 @@
 
 > **Document Control**  
 > **Framework:** Kairos Ontology Toolkit  
-> **Document date:** 2026-06-11
+> **Document date:** 2026-06-15
 
 | Item | Details |
 |---|---|


### PR DESCRIPTION
## Changes
- updated logistics .intro docs to reflect latest accelerator/reference-model versions
- updated document control dates to 2026-06-15
- added version snapshot tables in intro readmes and model selection overview

## Checklist
- [x] validation run (py scripts/validate_structure.py) passed
- [x] security review passed (docs-only change; no secrets/code paths)