### PR TITLE
Drop the unread folder: key from data-domains blueprints (#38)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### data-domains — drop the unread `folder:` key (#38)
+
+#### Removed
+- The `folder: "model/ontologies/<id>/"` key from all 22 domains in each of the logistics and
+  financial-services `client-hub-blueprint/data-domains.yaml` files, and its declaration from
+  `accelerator-packs/_schema/data-domains.schema.json`. The key stated a directory-per-domain
+  layout nothing implements: the toolkit derives the flat `model/ontologies/<id>.ttl` path from
+  `id` and never reads `folder`, so the key was a second place for the path convention to drift
+  (closes #38).
+
 Two changes, both from the same QA pass and shipping together. **Part 2** names the contract and
 retires the last hand-maintained restatement of it; **Part 1** below made the derived surfaces
 generated or tested.

--- a/ontology-reference-models/accelerator-packs/_schema/data-domains.schema.json
+++ b/ontology-reference-models/accelerator-packs/_schema/data-domains.schema.json
@@ -47,10 +47,9 @@
         "id": {
           "type": "string",
           "pattern": "^[a-z][a-z0-9-]*$",
-          "$comment": "Matched against hub ontology file stems by cli/shared.py::_ontology_domain_hints."
+          "$comment": "Matched against hub ontology file stems by cli/shared.py::_ontology_domain_hints. The toolkit derives the flat hub layout model/ontologies/<id>.ttl from this id; there is no per-domain folder (issue #38)."
         },
         "name": {"type": "string", "minLength": 1},
-        "folder": {"type": "string"},
         "owns": {"type": "string", "minLength": 1},
         "does_not_own": {"type": "string", "minLength": 1},
         "grain_note": {

--- a/ontology-reference-models/accelerator-packs/financial-services/client-hub-blueprint/data-domains.yaml
+++ b/ontology-reference-models/accelerator-packs/financial-services/client-hub-blueprint/data-domains.yaml
@@ -20,7 +20,6 @@ groups:
 
       - id: party
         name: "Party, Person & Agent"
-        folder: "model/ontologies/party/"
         owns: "Legal persons, natural persons, autonomous agents, party roles, contact details, and party identifiers."
         does_not_own: "Corporate structure, ownership chains, financial instruments, contracts, or transactions."
         imports:
@@ -42,7 +41,6 @@ groups:
 
       - id: organisation
         name: "Organisation, Corporate Structure & Ownership"
-        folder: "model/ontologies/organisation/"
         owns: "Formal organisations, corporate hierarchy, ownership chains, control relationships, partnerships, trusts, and sole proprietorships."
         does_not_own: "Natural persons, party roles, financial instruments, regulatory filings, or market data."
         imports:
@@ -79,7 +77,6 @@ groups:
 
       - id: regulatory
         name: "Government, Regulatory & Jurisdictional"
-        folder: "model/ontologies/regulatory/"
         owns: "Government entities, regulatory bodies, jurisdictions, legal frameworks, and legal capacity."
         does_not_own: "Compliance obligations, audit evidence, financial instruments, or market infrastructure."
         imports:
@@ -98,7 +95,6 @@ groups:
 
       - id: financial-market-participants
         name: "Financial Market Participants & Infrastructure"
-        folder: "model/ontologies/financial-market-participants/"
         owns: "Exchanges, clearing houses, registries, central counterparties, financial intermediaries, financial service providers, and market infrastructure entities."
         does_not_own: "Legal entity master data, party contact details, financial instruments, or market data."
         imports:
@@ -125,7 +121,6 @@ groups:
 
       - id: contracts
         name: "Agreements, Contracts & Obligations"
-        folder: "model/ontologies/contracts/"
         owns: "Legal agreements, contracts, contractual terms, conditions, obligations, warranties, and contract lifecycle."
         does_not_own: "Financial instrument terms, ACTUS cashflow analytics, product catalogs, or transaction settlement."
         imports:
@@ -140,7 +135,6 @@ groups:
 
       - id: products-services
         name: "Financial Products & Services"
-        folder: "model/ontologies/products-services/"
         owns: "Product catalogs, service offerings, product types, payment schedules, and product lifecycle."
         does_not_own: "Specific instrument types (securities, derivatives, loans), market data, or party master data."
         imports:
@@ -159,7 +153,6 @@ groups:
 
       - id: actus-contract-analytics
         name: "ACTUS Contract Terms & Cashflow Analytics"
-        folder: "model/ontologies/actus/"
         owns: "Algorithmic contract types, contract term definitions, cashflow taxonomy, contract state machines, and term applicability."
         does_not_own: "Legal contract lifecycle, product catalogs, settlement, or market data."
         imports:
@@ -179,7 +172,6 @@ groups:
 
       - id: instruments
         name: "Core Financial Instruments"
-        folder: "model/ontologies/instruments/"
         owns: "Instrument base concepts, instrument identifiers (ISIN, CUSIP, FIGI), debt and equity instrument foundations, and instrument classification."
         does_not_own: "Specific security types, derivative contracts, loan products, or market prices."
         imports:
@@ -197,7 +189,6 @@ groups:
 
       - id: securities
         name: "Securities — Debt, Equities & Funds"
-        folder: "model/ontologies/securities/"
         owns: "Bonds, notes, equities, shares, fund units, ETFs, security identifiers, listings, restrictions, and issuance details."
         does_not_own: "Derivatives, loans, market prices/yields, or corporate actions."
         imports:
@@ -221,7 +212,6 @@ groups:
 
       - id: derivatives
         name: "Derivatives — Options, Futures, Swaps"
-        folder: "model/ontologies/derivatives/"
         owns: "Options, futures, forwards, swaps, credit derivatives, rate derivatives, security-based derivatives, and derivative contract terms."
         does_not_own: "Underlying securities, loans, market data, or settlement transactions."
         imports:
@@ -248,7 +238,6 @@ groups:
 
       - id: loans
         name: "Loans — Commercial, Consumer & Mortgage"
-        folder: "model/ontologies/loans/"
         owns: "Loan products, loan terms, amortisation schedules, collateral, borrower/lender roles, mortgage specifics, and loan lifecycle."
         does_not_own: "Securities, derivatives, market data, or party master data."
         imports:
@@ -274,7 +263,6 @@ groups:
 
       - id: market-data
         name: "Market Data — Prices, Yields & Analytics"
-        folder: "model/ontologies/market-data/"
         owns: "Market prices, yields, spreads, analytics, valuations, and temporal market snapshots."
         does_not_own: "Instrument definitions, economic indicators, FX rates, or index compositions."
         imports:
@@ -295,7 +283,6 @@ groups:
 
       - id: indicators
         name: "Indicators, Indices, FX & Interest Rates"
-        folder: "model/ontologies/indicators/"
         owns: "Economic indicators, foreign exchange rates, interest rate benchmarks, market indices, and reference rates."
         does_not_own: "Instrument-level market data, security prices, or transaction data."
         imports:
@@ -321,7 +308,6 @@ groups:
 
       - id: transactions
         name: "Transactions, Settlement & Positions"
-        folder: "model/ontologies/transactions/"
         owns: "Financial transactions, trade execution, settlement, clearing, position keeping, and transaction lifecycle."
         does_not_own: "Instrument definitions, accounting entries, market data, or contract terms."
         imports:
@@ -339,7 +325,6 @@ groups:
 
       - id: accounting
         name: "Accounting, Ledger & Financial Reporting"
-        folder: "model/ontologies/accounting/"
         owns: "Accounting entries, ledger balances, currency amounts, cashflows, equity accounting, and financial reporting."
         does_not_own: "Transaction execution, instrument definitions, party master data, or market data."
         imports:
@@ -361,7 +346,6 @@ groups:
 
       - id: corporate-actions
         name: "Corporate Actions & Events"
-        folder: "model/ontologies/corporate-actions/"
         owns: "Corporate actions, stock splits, dividends, rights issues, mergers, tender offers, and corporate event lifecycle."
         does_not_own: "Securities definitions, market prices, transaction settlement, or party master data."
         imports:
@@ -373,7 +357,6 @@ groups:
 
       - id: securities-issuance
         name: "Securities Issuance Process"
-        folder: "model/ontologies/securities-issuance/"
         owns: "Securities issuance workflows, IPO process, underwriting, bookbuilding, allocation, and issuance lifecycle."
         does_not_own: "Security definitions, corporate actions post-issuance, market data, or settlement."
         imports:
@@ -394,7 +377,6 @@ groups:
 
       - id: reference-data
         name: "Reference Data, Identifiers & Classifications"
-        folder: "model/ontologies/reference-data/"
         owns: "Shared identifiers, code lists, classification schemes, places, addresses, dates, time concepts, ratings, and arrangements."
         does_not_own: "Domain-specific transactions, instrument definitions, or party master data."
         imports:
@@ -437,7 +419,6 @@ groups:
 
       - id: compliance
         name: "Compliance, Governance & Audit"
-        folder: "model/ontologies/compliance/"
         owns: "Regulatory compliance obligations, governance policies, audit evidence, KYC/AML requirements, and reporting obligations."
         does_not_own: "Regulatory body definitions, party master data, financial instruments, or transactions."
         imports: []
@@ -446,7 +427,6 @@ groups:
 
       - id: mdm
         name: "MDM Hub (Golden Records, Crosswalks, Match/Merge)"
-        folder: "model/ontologies/mdm/"
         owns: "Golden records, crosswalks (source-to-golden links), source system registry, match groups, merge events, and survivorship rules."
         does_not_own: "Domain-specific entity definitions — it masters them via reference."
         imports: []
@@ -461,7 +441,6 @@ groups:
 
       - id: insurance
         name: "Insurance — Policy, Claims & Underwriting"
-        folder: "model/ontologies/insurance/"
         owns: "Insurance policies, claims, underwriting, premiums, coverage, loss events, and actuarial concepts."
         does_not_own: "Core financial instruments, banking products, securities, or market data."
         imports: []
@@ -471,7 +450,6 @@ groups:
 
       - id: trade-finance
         name: "Trade Finance — Letters of Credit, Guarantees & Collections"
-        folder: "model/ontologies/trade-finance/"
         owns: "Letters of credit, bank guarantees, documentary collections, trade finance instruments, and documentary workflows."
         does_not_own: "General contracts, securities, derivatives, or party master data."
         imports: []

--- a/ontology-reference-models/accelerator-packs/logistics/client-hub-blueprint/data-domains.yaml
+++ b/ontology-reference-models/accelerator-packs/logistics/client-hub-blueprint/data-domains.yaml
@@ -20,7 +20,6 @@ groups:
 
       - id: party
         name: "Party, Role & Organisation"
-        folder: "model/ontologies/party/"
         owns: "Legal entities, customers, suppliers, carriers, terminal operators, agents, authorities, contacts, roles, and organisational hierarchy."
         does_not_own: "Contracts, bookings, invoices, operational events, or terminal moves."
         imports:
@@ -45,7 +44,6 @@ groups:
 
       - id: commercial
         name: "Customer, Contract & Commercial Agreement"
-        folder: "model/ontologies/commercial/"
         owns: "Commercial relationships, service agreements, trade terms, customer commitments, pricing conditions at contract level."
         does_not_own: "Surcharge calculation, invoice posting, booking execution, or terminal tariff events."
         imports:
@@ -58,7 +56,6 @@ groups:
 
       - id: booking
         name: "Booking, Quote & Order Management"
-        folder: "model/ontologies/booking/"
         owns: "Booking requests, quotes, transport orders, customer instructions, booking confirmation, and booking lifecycle."
         does_not_own: "Transport execution events, invoices, vessel schedules, terminal handling, or the transport mode of any individual leg."
         grain_note: >
@@ -112,7 +109,6 @@ groups:
 
       - id: financial
         name: "Tariff, Surcharge, Invoice, Settlement & Operational Finance"
-        folder: "model/ontologies/financial/"
         owns: "Tariff structures, surcharges (BAF, CAF, THC, PSS), freight charges, demurrage and detention, invoices, credit notes, settlement, payment allocation, trade finance (L/C, documentary collection), cost allocation, cost-to-serve, budget variance, revenue attribution, yield metrics, load factor, and profitability analysis."
         does_not_own: "Customer contracts, booking lifecycle, emissions methodology, operational events, general ledger chart-of-accounts, or working capital metrics (DSO, DPO, cash conversion cycle) — those are client extensions."
         extension_note: >
@@ -153,7 +149,6 @@ groups:
 
       - id: consignment
         name: "Consignment, Shipment & Transport Movement"
-        folder: "model/ontologies/consignment/"
         owns: "Consignments, shipments, transport legs, multimodal chains, handovers, and transport status."
         does_not_own: "Terminal micro-events, commercial pricing, customs declarations, or vehicle service details."
         imports:
@@ -169,7 +164,6 @@ groups:
 
       - id: cargo
         name: "Cargo, Goods & Cargo Unit"
-        folder: "model/ontologies/cargo/"
         owns: "Cargo description, goods classification, packages, weights, dimensions, commodity attributes, and handling requirements."
         does_not_own: "Transport equipment, terminal moves, automotive services, or DG regulatory rules."
         overlaps:
@@ -191,7 +185,6 @@ groups:
 
       - id: equipment
         name: "Cargo Equipment & Fleet Equipment"
-        folder: "model/ontologies/equipment/"
         owns: "Trailers, containers, tank containers, reefer units, chassis, swap bodies, equipment identifiers, and equipment status."
         does_not_own: "Vessel fleet, terminal cranes, cargo contents, or operational moves."
         imports:
@@ -207,7 +200,6 @@ groups:
 
       - id: route-schedule
         name: "Route, Network, Schedule & Service"
-        folder: "model/ontologies/route-schedule/"
         owns: "Service network, routes, corridors, sailing schedules, service loops, cut-offs, and transit times."
         does_not_own: "Actual cargo loaded, terminal moves, invoices, or customer contracts."
         imports:
@@ -226,7 +218,6 @@ groups:
 
       - id: intermodal
         name: "Intermodal Rail, Barge & Inland Execution"
-        folder: "model/ontologies/intermodal/"
         owns: "Inland legs, rail/barge connections, road execution, terminal-to-terminal handovers, inland route execution, train running and rolling-stock composition."
         does_not_own: "Maritime voyage execution, terminal yard moves, cargo master data, customer contracts, or the rail path/consignment reservation (that is booking, grain 3)."
         grain_note: >
@@ -257,7 +248,6 @@ groups:
 
       - id: vessel-maritime
         name: "Vessel, Fleet & Maritime Operations"
-        folder: "model/ontologies/vessel-maritime/"
         owns: "Vessels, vessel characteristics, voyages, sea legs, port calls, berthing, fleet capabilities, statutory certificates, crew management, environmental compliance (SEEMP, BWMP, SOPEP), and maritime security (ISPS, ship security plans)."
         does_not_own: "Terminal yard moves, customer bookings, cargo commercial terms, or emissions formulas."
         overlaps:
@@ -296,7 +286,6 @@ groups:
 
       - id: terminal-operations
         name: "Terminal, Yard, Berth, Gate & Handling Operations"
-        folder: "model/ontologies/terminal-operations/"
         owns: "Terminal infrastructure, yard areas, gates, berths, storage zones, stevedoring, load/discharge moves, and handling instructions."
         does_not_own: "Customer contracts, route network, vessel master data, cargo semantics, or customs declarations."
         imports:
@@ -318,7 +307,6 @@ groups:
 
       - id: roro
         name: "RoRo Operations"
-        folder: "model/ontologies/roro/"
         owns: "RoRo-specific cargo concepts: trailers, self-drive units, rolling machinery, lane-metre planning, RoRo load/discharge context."
         does_not_own: "Generic cargo master data, vessel master data, terminal yard moves, or commercial charges."
         imports:
@@ -335,7 +323,6 @@ groups:
 
       - id: automotive
         name: "Automotive Logistics & Vehicle Services"
-        folder: "model/ontologies/automotive/"
         owns: "Vehicle-unit lifecycle, PDI, wash, enhancement, modification, technical service, body repair, storage, and release readiness."
         does_not_own: "Generic RoRo handling, general cargo classification, terminal yard master data, or contract terms."
         imports:
@@ -352,7 +339,6 @@ groups:
 
       - id: dangerous-goods
         name: "Dangerous Goods & Cargo Restrictions"
-        folder: "model/ontologies/dangerous-goods/"
         owns: "DG restrictions, hazardous cargo attributes, acceptance rules, route/terminal/vessel restrictions, and regulatory classes."
         does_not_own: "All cargo classification, customs declarations, booking lifecycle, or incident response."
         imports:
@@ -365,7 +351,6 @@ groups:
 
       - id: customs
         name: "Customs, Border & Regulatory Declarations"
-        folder: "model/ontologies/customs/"
         owns: "Customs declarations, goods items, packaging, customs procedures, border filings, regulatory declarations, declarants, brokers, consignees/consignors, customs documents (SAD, carnets), customs offices, border crossings, bonded warehouses, free zones, and regulatory status."
         does_not_own: "Transport execution, cargo operations, commercial contracts, or DG acceptance rules."
         overlaps:
@@ -395,7 +380,6 @@ groups:
 
       - id: compliance
         name: "Compliance, Governance, Policy & Legal"
-        folder: "model/ontologies/compliance/"
         owns: "Regulatory policies, corporate governance, privacy, audit evidence, and legal document metadata."
         does_not_own: "Customs filings, cargo restrictions, commercial contracts, or invoice settlement."
         imports:
@@ -407,7 +391,6 @@ groups:
 
       - id: sustainability
         name: "Sustainability, Carbon, Energy & ESG"
-        folder: "model/ontologies/sustainability/"
         owns: "Carbon intensity, emissions factors, energy consumption, modal-shift metrics, Scope 1/2/3 reporting, and ESG indicators."
         does_not_own: "Commercial surcharge pricing, operational events, or vessel/terminal master data."
         imports:
@@ -429,7 +412,6 @@ groups:
 
       - id: events
         name: "Track & Trace / Operational Events"
-        folder: "model/ontologies/events/"
         owns: "Normalised event model across cargo, equipment, vessel, terminal, gate, handover, and multimodal transport events."
         does_not_own: "Master definitions of cargo, vessel, equipment, terminal, route, or customer."
         overlaps:
@@ -461,7 +443,6 @@ groups:
 
       - id: claims
         name: "Claims, Damage, Exception & Incident Management"
-        folder: "model/ontologies/claims/"
         owns: "Damage records, claims, operational exceptions, incidents, root-cause classification, and resolution status."
         does_not_own: "Routine operational events, cargo master data, vehicle service completion, or invoice settlement."
         imports: []
@@ -470,7 +451,6 @@ groups:
 
       - id: documents
         name: "Documents, Messages & Evidence"
-        folder: "model/ontologies/documents/"
         owns: "Business and transport documents, message metadata, document versions, evidence, and document-to-shipment links."
         does_not_own: "Semantic truth of cargo, bookings, customs, or invoices — references them via links."
         imports:
@@ -489,7 +469,6 @@ groups:
 
       - id: reference-data
         name: "Master Data, Code Lists & Reference Data"
-        folder: "model/ontologies/reference-data/"
         owns: "Shared identifiers, code lists, location codes, port codes, equipment type codes, status codes, UoM, and currency."
         does_not_own: "Domain-specific transactions or operational events."
         imports:
@@ -512,7 +491,6 @@ groups:
 
       - id: mdm
         name: "MDM Hub (Golden Records, Crosswalks, Match/Merge)"
-        folder: "model/ontologies/mdm/"
         owns: "Golden records, crosswalks (source-to-golden links), source system registry, match groups, merge events, and survivorship rules."
         does_not_own: "Domain-specific entity definitions — it masters them via reference."
         imports: []


### PR DESCRIPTION
Closes #38.

The `folder: "model/ontologies/<id>/"` key stated a directory-per-domain layout nothing implements: the toolkit's `load_data_domains()` never reads it and derives the flat `model/ontologies/<id>.ttl` path from `id` (confirmed against toolkit v5.2.1 — six non-recursive glob call sites plus `_ontology_domain_hints` all assume the flat layout).

- Removed from all 22 domains in each of the **logistics** and **financial-services** `client-hub-blueprint/data-domains.yaml` files (the issue counted logistics only; the financial-services blueprint had the same 22).
- Removed from `accelerator-packs/_schema/data-domains.schema.json` in the same commit (`additionalProperties: false` couples the two); the `id` `$comment` now records the derived flat layout.
- `examples/` swept — no `folder:` references.

Option 2 from the issue (drop, don't rename): `id` already determines the filename, so this removes the second place for the path convention to drift.

Verified: full pytest suite, `generate_logistics_inventory.py --check`, `validate_logistics_blueprint.py`, `generate_pack_docs.py --check`, `validate_structure.py` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)