### PR TITLE
Bump the toolkit pin to 5.2.3rc1 to green the cross-repo-contract job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,9 +75,18 @@ The contract was tested; the corpus was not.
   `<uri>` targets and is blind to a wrong `rewritePrefix`; resolution is now proven by
   execution instead.
 
+#### Changed — toolkit pin
+- **Pinned toolkit bumped 5.2.1rc9 → 5.2.3rc1**, the `preview` channel head and the exact
+  version the client hub reported gh#57 against. The pin check is time-dependent — it
+  compares against whatever the channel has released since — so it went red on `main` as
+  soon as 5.2.3rc1 shipped, independently of any change here. Bumping also means the fix
+  is verified against the version that produced the original report, not just the version
+  that happened to be pinned when it was written.
+
 #### Result
-`generate-inventory` over the bundle: **82 of 82 inventories, zero failures, zero
-collisions** (was 78 generated, 3 closure failures, 1 collision).
+`generate-inventory` over the bundle, on both 5.2.1rc9 and 5.2.3rc1: **82 of 82
+inventories, zero failures, zero collisions** (was 78 generated, 3 closure failures,
+1 collision).
 
 ## [1.16.0] - 2026-08-13
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Kairos ontology hub — kairos-ontology-referencemodels"
 requires-python = ">=3.12"
 dependencies = [
-    "kairos-ontology-toolkit @ https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.1rc9/kairos_ontology_toolkit-5.2.1rc9-py3-none-any.whl",
+    "kairos-ontology-toolkit @ https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.3rc1/kairos_ontology_toolkit-5.2.3rc1-py3-none-any.whl",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.0" },
-    { name = "kairos-ontology-toolkit", url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.1rc9/kairos_ontology_toolkit-5.2.1rc9-py3-none-any.whl" },
+    { name = "kairos-ontology-toolkit", url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.3rc1/kairos_ontology_toolkit-5.2.3rc1-py3-none-any.whl" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'dev'", specifier = ">=7.4" },
@@ -271,8 +271,8 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "kairos-ontology-toolkit"
-version = "5.2.1rc9"
-source = { url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.1rc9/kairos_ontology_toolkit-5.2.1rc9-py3-none-any.whl" }
+version = "5.2.3rc1"
+source = { url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.3rc1/kairos_ontology_toolkit-5.2.3rc1-py3-none-any.whl" }
 dependencies = [
     { name = "click" },
     { name = "jinja2" },
@@ -288,7 +288,7 @@ dependencies = [
     { name = "rdflib" },
 ]
 wheels = [
-    { url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.1rc9/kairos_ontology_toolkit-5.2.1rc9-py3-none-any.whl", hash = "sha256:a14a7edc329875ef262ce4349d49d965c4d99aefd5e5af918ebe3ae3b136971c" },
+    { url = "https://github.com/Cnext-eu/kairos-ontology-toolkit/releases/download/v5.2.3rc1/kairos_ontology_toolkit-5.2.3rc1-py3-none-any.whl", hash = "sha256:a5d4f4fba2cf81b66b0b7fcc90314ffe171455561f016cec95dae4dee430acb4" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
`main` is red after #58 merged. The failure is **not** from #58 — it is the `Check the toolkit pin is current for its channel` step:

```
✗ Toolkit pin is behind: pinned 5.2.1rc9, latest 'preview' is 5.2.3rc1.
```

`check_toolkit_pin.py --check` compares the pin against the *current head* of its channel, so it is time-dependent: it goes red the moment the toolkit publishes a newer preview, with no change in this repo. The last green run here was v1.16.0, before 5.2.3rc1 shipped.

## Why bump rather than wait

`5.2.3rc1` is the exact version the client hub reported #57 against. Bumping means the bundle-conformance fix is verified against the toolkit that produced the original report, not just the one that happened to be pinned when the issue was written.

## Verification on 5.2.3rc1

- `tests/test_toolkit_contract.py` + `tests/test_bundle_conformance.py` — 9 passed
- Full suite — 100 passed, 6 skipped
- All seven validation scripts OK
- `generate-inventory` over the bundle — **82 of 82 inventories, zero failures, zero collisions**

So the #57 fix holds on both 5.2.1rc9 and 5.2.3rc1.

Diff is `pyproject.toml` (the pinned wheel URL) and the regenerated `uv.lock`, plus a CHANGELOG line under the unreleased 1.17.0 section.

This needs to land before `v1.17.0` is tagged — `release.yml` should not run over a red `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)