### PR TITLE
Attach assets to a pre-existing release instead of failing on it

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
             echo "See CHANGELOG.md for details." > RELEASE_NOTES.md
           fi
 
-      - name: Create GitHub Release
+      - name: Create GitHub Release, or attach assets to an existing one
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -99,12 +99,26 @@ jobs:
           case "$VERSION" in
             *-*) PRERELEASE_FLAG="--prerelease" ;;
           esac
-          gh release create "v$VERSION" \
-            --title "Release $VERSION" \
-            --notes-file RELEASE_NOTES.md \
-            $PRERELEASE_FLAG \
-            "kairos-reference-models-$VERSION.tar.gz" \
-                        "dist/kairos_ontology_referencemodels-$VERSION-py3-none-any.whl"
+          ASSETS=(
+            "kairos-reference-models-$VERSION.tar.gz"
+            "dist/kairos_ontology_referencemodels-$VERSION-py3-none-any.whl"
+          )
+          if gh release view "v$VERSION" --json id >/dev/null 2>&1; then
+            # Publishing a release from the GitHub UI creates the tag, and the tag
+            # triggers this workflow — so an existing release is the normal outcome
+            # of a hand-drafted release, not an error. Keep its hand-written title
+            # and notes; attach the built artifacts. --clobber makes a re-run after
+            # a partial upload safe. (v1.20.1 shipped asset-less because this case
+            # used to fail: "a release with the same tag name already exists".)
+            echo "Release v$VERSION already exists — uploading assets to it."
+            gh release upload "v$VERSION" --clobber "${ASSETS[@]}"
+          else
+            gh release create "v$VERSION" \
+              --title "Release $VERSION" \
+              --notes-file RELEASE_NOTES.md \
+              $PRERELEASE_FLAG \
+              "${ASSETS[@]}"
+          fi
       
       - name: Publish to artifact registry (optional)
         if: false  # Enable when Azure Blob Storage is configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the Kairos Reference Models will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **A hand-drafted GitHub release no longer ships without assets.** Publishing a release
+  from the GitHub UI creates the tag, and the tag triggers `release.yml` — whose
+  `gh release create` then failed with "a release with the same tag name already exists",
+  after building the artifacts but before attaching them. That is how v1.20.1 shipped with
+  neither the wheel nor the tarball (repaired by deleting the empty release and re-running
+  the job, hand-written notes preserved). The create step now detects an existing release
+  and uploads the assets to it instead, keeping its hand-written title and notes;
+  `--clobber` makes re-runs after a partial upload safe.
+
 ## [1.20.1] - 2026-08-15
 
 ### Fixed


### PR DESCRIPTION
## The defect (how v1.20.1 shipped without a wheel)

Publishing a release from the **GitHub UI creates the tag**, and the tag push triggers `release.yml`. The workflow validated, built the wheel and tarball (the #80 path fix works), then died at the last step:

```
gh release create "v1.20.1" ...
a release with the same tag name already exists: v1.20.1
```

— after the artifacts were built, before anything was attached. So v1.20.1 sat published with **zero assets**. (Since repaired: empty release deleted, failed job re-run — both assets now attached — and the hand-written notes restored over the CHANGELOG-generated ones.)

## The fix

An existing release is the *normal* outcome of a hand-drafted release, not an error. The create step now branches:

- release exists → `gh release upload --clobber` the two assets to it, **keeping its hand-written title and notes** (deliberately not overwriting them with the CHANGELOG extraction);
- release absent → `gh release create` exactly as before.

`--clobber` also makes a re-run after a partial upload safe. Fails safe: if `gh release view` errors for any reason other than absence, the create path runs and fails loudly as today.

The `workflow_call` validate gate (#60) is untouched; this only changes the final publish step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)